### PR TITLE
feat(ui): Improve the banner component

### DIFF
--- a/lib/main.directories.g.dart
+++ b/lib/main.directories.g.dart
@@ -14,8 +14,8 @@ import 'package:flex_ui/widgets/banner/banner.dart' as _i3;
 import 'package:widgetbook/widgetbook.dart' as _i1;
 
 final directories = <_i1.WidgetbookNode>[
-  _i1.WidgetbookFolder(
-    name: 'widgets',
+  _i1.WidgetbookCategory(
+    name: 'Components',
     children: [
       _i1.WidgetbookComponent(
         name: 'AddToCartButton',
@@ -38,17 +38,12 @@ final directories = <_i1.WidgetbookNode>[
           ),
         ],
       ),
-      _i1.WidgetbookFolder(
-        name: 'banner',
-        children: [
-          _i1.WidgetbookLeafComponent(
-            name: 'FlexBanner',
-            useCase: _i1.WidgetbookUseCase(
-              name: 'Minimal',
-              builder: _i3.minimalBanner,
-            ),
-          )
-        ],
+      _i1.WidgetbookLeafComponent(
+        name: 'FlexBanner',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Standard',
+          builder: _i3.standardBanner,
+        ),
       ),
     ],
   )

--- a/lib/widgets/add_to_cart_button.dart
+++ b/lib/widgets/add_to_cart_button.dart
@@ -52,6 +52,7 @@ class AddToCartButton extends StatelessWidget {
 @widgetbook.UseCase(
   name: 'Default',
   type: AddToCartButton,
+  path: '[Components]',
 )
 Widget defaultButton(BuildContext context) {
   return Center(
@@ -64,6 +65,7 @@ Widget defaultButton(BuildContext context) {
 @widgetbook.UseCase(
   name: 'Loading',
   type: AddToCartButton,
+  path: '[Components]',
 )
 Widget loadingButton(BuildContext context) {
   return Center(
@@ -77,6 +79,7 @@ Widget loadingButton(BuildContext context) {
 @widgetbook.UseCase(
   name: 'Disabled',
   type: AddToCartButton,
+  path: '[Components]',
 )
 Widget disabledButton(BuildContext context) {
   return Center(
@@ -90,6 +93,7 @@ Widget disabledButton(BuildContext context) {
 @widgetbook.UseCase(
   name: 'Small',
   type: AddToCartButton,
+  path: '[Components]',
 )
 Widget smallButton(BuildContext context) {
   return Center(

--- a/lib/widgets/banner/banner.dart
+++ b/lib/widgets/banner/banner.dart
@@ -24,14 +24,14 @@ class FlexBanner extends StatelessWidget {
     this.orientation = Axis.horizontal,
     this.imageLayout = FlexBannerImageLayout.end,
     this.theme,
-    this.heading,
+    this.overline,
     this.description,
     this.button,
   });
 
   final Widget title;
 
-  final FlexImage image;
+  final Widget image;
 
   final Axis orientation;
 
@@ -39,14 +39,12 @@ class FlexBanner extends StatelessWidget {
 
   final CardTheme? theme;
 
-  // TODO Implement this, I'm thinking a heading line above the title to emphasise the title
-  final Widget? heading;
+  final Widget? overline;
 
-  // TODO Implement this
   final Widget? description;
 
-  /// TODO Make a standard button. Also: should be a list of buttons for more flexibility
-  final AddToCartButton? button;
+  /// TODO Implement this, also: make it a List<Widget>?
+  final Widget? button;
 
   @override
   Widget build(BuildContext context) {
@@ -54,21 +52,23 @@ class FlexBanner extends StatelessWidget {
     final MainLayout = orientation == Axis.horizontal ? Row.new : Column.new;
 
     final cardChildren = [
-      Padding(
-        padding: const EdgeInsets.all(FlexSizes.spacerDefault),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (heading != null) ...[
-              heading!,
-              const SizedBox(height: FlexSizes.spacerDefault),
+      Flexible(
+        child: Padding(
+          padding: const EdgeInsets.all(FlexSizes.spacerDefault),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (overline != null) ...[
+                overline!,
+                const SizedBox(height: FlexSizes.spacerDefault),
+              ],
+              title,
+              if (description != null) ...[
+                const SizedBox(height: FlexSizes.spacerDefault),
+                description!,
+              ],
             ],
-            title,
-            if (description != null) ...[
-              const SizedBox(height: FlexSizes.spacerDefault),
-              description!,
-            ],
-          ],
+          ),
         ),
       ),
       Flexible(child: image),
@@ -108,10 +108,11 @@ class FlexBanner extends StatelessWidget {
 }
 
 @widgetbook.UseCase(
-  name: 'Minimal',
+  name: 'Standard',
   type: FlexBanner,
+  path: '[Components]',
 )
-Widget minimalBanner(BuildContext context) {
+Widget standardBanner(BuildContext context) {
   final color = context.knobs.colorOrNull(
     label: 'Background Color',
     initialValue: null,
@@ -120,14 +121,41 @@ Widget minimalBanner(BuildContext context) {
   final theme =
       color != null ? CardTheme.of(context).copyWith(color: color) : null;
 
+  final overlineText = context.knobs.stringOrNull(
+    label: 'Heading',
+    initialValue: 'FEATURED',
+  );
+
+  final descriptionText = context.knobs.stringOrNull(
+    label: 'Description',
+    initialValue:
+        'Feeling spooky? Get our best halloween deals now before it\'s too late!',
+  );
+
   return Center(
     child: FlexBanner(
+      overline: overlineText != null
+          ? Text(
+              overlineText,
+              style: Theme.of(context).textTheme.labelSmall,
+              textAlign: TextAlign.center,
+            )
+          : null,
       title: Text(
         context.knobs.string(
           label: 'Title',
           initialValue: 'Halloween specials!',
         ),
+        style: Theme.of(context).textTheme.titleMedium,
+        textAlign: TextAlign.center,
       ),
+      description: descriptionText != null
+          ? Text(
+              descriptionText,
+              style: Theme.of(context).textTheme.bodySmall,
+              textAlign: TextAlign.center,
+            )
+          : null,
       image: const FlexImage(
         'https://loremflickr.com/240/320?lock=666',
         placeholder: SizedBox.shrink(),

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,3 +1,11 @@
 # playground
 
-A new Flutter project.
+Flex UI playground used for the examples in the documentation (https://github.com/flex-storefront/flex-docs)
+
+## Publishing
+
+- Make sure you are in the `/playground` folder, otherwise you'll build the WidgetBook app instead of the playground.
+- Run `flutter build web`
+- Login in Firebase CLI with an account with administrator rights on `flex-ui-playground`
+- Run `firebase use flex-ui-playground`
+- Run `firebase deploy`

--- a/playground/lib/pages/banner.dart
+++ b/playground/lib/pages/banner.dart
@@ -3,8 +3,8 @@ import 'package:flex_ui/flex_ui.dart';
 import 'package:flutter/material.dart';
 
 @RoutePage()
-class BannerPage extends StatelessWidget {
-  const BannerPage({super.key});
+class BannerMinimalPage extends StatelessWidget {
+  const BannerMinimalPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -13,6 +13,40 @@ class BannerPage extends StatelessWidget {
       child: FlexBanner(
         title: Text('Halloween specials!'),
         image: FlexImage(
+          'https://unsplash.it/320/280',
+          width: 320,
+          height: 280,
+        ),
+      ),
+    ));
+  }
+}
+
+@RoutePage()
+class BannerFullPage extends StatelessWidget {
+  const BannerFullPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        body: Center(
+      child: FlexBanner(
+        overline: Text(
+          'FEATURED',
+          style: Theme.of(context).textTheme.labelSmall,
+          textAlign: TextAlign.center,
+        ),
+        title: Text(
+          'Halloween specials!',
+          style: Theme.of(context).textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+        description: Text(
+          'Get you hands on the latest Halloween\ndeals before it\'s too late!',
+          style: Theme.of(context).textTheme.bodySmall,
+          textAlign: TextAlign.center,
+        ),
+        image: const FlexImage(
           'https://unsplash.it/320/280',
           width: 320,
           height: 280,

--- a/playground/lib/router.dart
+++ b/playground/lib/router.dart
@@ -12,7 +12,8 @@ class AppRouter extends RootStackRouter {
   List<AutoRoute> get routes => [
         AutoRoute(page: HomeRoute.page, path: '/'),
         AutoRoute(page: AddToCartRoute.page, path: '/add-to-cart'),
-        AutoRoute(page: BannerRoute.page, path: '/banner'),
+        AutoRoute(page: BannerMinimalRoute.page, path: '/banner-minimal'),
+        AutoRoute(page: BannerFullRoute.page, path: '/banner-full'),
         AutoRoute(page: ImageRoute.page, path: '/image'),
       ];
 }

--- a/playground/lib/router.gr.dart
+++ b/playground/lib/router.gr.dart
@@ -29,20 +29,39 @@ class AddToCartRoute extends PageRouteInfo<void> {
 }
 
 /// generated route for
-/// [BannerPage]
-class BannerRoute extends PageRouteInfo<void> {
-  const BannerRoute({List<PageRouteInfo>? children})
+/// [BannerFullPage]
+class BannerFullRoute extends PageRouteInfo<void> {
+  const BannerFullRoute({List<PageRouteInfo>? children})
       : super(
-          BannerRoute.name,
+          BannerFullRoute.name,
           initialChildren: children,
         );
 
-  static const String name = 'BannerRoute';
+  static const String name = 'BannerFullRoute';
 
   static PageInfo page = PageInfo(
     name,
     builder: (data) {
-      return const BannerPage();
+      return const BannerFullPage();
+    },
+  );
+}
+
+/// generated route for
+/// [BannerMinimalPage]
+class BannerMinimalRoute extends PageRouteInfo<void> {
+  const BannerMinimalRoute({List<PageRouteInfo>? children})
+      : super(
+          BannerMinimalRoute.name,
+          initialChildren: children,
+        );
+
+  static const String name = 'BannerMinimalRoute';
+
+  static PageInfo page = PageInfo(
+    name,
+    builder: (data) {
+      return const BannerMinimalPage();
     },
   );
 }


### PR DESCRIPTION
Improve the banner component by supporting long texts. Also: parts are defined as `Widget` rather than a String or a specific widget such as `FlexImage` for more flexibility.

<img width="658" alt="image" src="https://github.com/user-attachments/assets/6ce13468-de18-46ce-9152-eed398f24387">

Also in this PR:
- More controls on the widgetbook page
- Widgetbook pages re-organized
- Additional banner example in the playground
- Deploying instructions for the playground web app