### PR TITLE
feat: Create custom ColorSchemes and refactoring code

### DIFF
--- a/app/lib/theme/flex_app_themes.dart
+++ b/app/lib/theme/flex_app_themes.dart
@@ -12,33 +12,39 @@ import 'package:flutter/material.dart';
 class FlexAppThemes {
   static ThemeData lightTheme = ThemeData(
     useMaterial3: true,
-    appBarTheme: const AppBarTheme(
+    extensions: const [FlexAppColorScheme.light],
+    appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
       surfaceTintColor: Colors.transparent,
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-      iconTheme: IconThemeData(color: Colors.black, size: FlexSizes.iconMd),
-      actionsIconTheme:
-          IconThemeData(color: FlexColors.primary, size: FlexSizes.iconMd),
+      iconTheme: IconThemeData(
+        color: FlexAppColorScheme.light.primary,
+        size: FlexSizes.iconMd,
+      ),
+      actionsIconTheme: IconThemeData(
+        color: FlexAppColorScheme.light.primary,
+        size: FlexSizes.iconMd,
+      ),
       titleTextStyle: TextStyle(
         fontSize: FlexSizes.fontSizeXl,
         fontWeight: FontWeight.w600,
-        color: FlexColors.primary,
+        color: FlexAppColorScheme.light.primary,
       ),
     ),
     brightness: Brightness.light,
     navigationBarTheme: NavigationBarThemeData(
-      backgroundColor: FlexColors.primary.withOpacity(0.15),
-      indicatorColor: FlexColors.secondary.withOpacity(0.1),
+      backgroundColor: FlexAppColorScheme.light.primary.withOpacity(0.15),
+      indicatorColor: FlexAppColorScheme.light.secondary.withOpacity(0.1),
     ),
-    primaryColor: FlexColors.primary,
-    disabledColor: FlexColorsDark.disabled,
-    scaffoldBackgroundColor: FlexColors.scaffold,
+    primaryColor: FlexAppColorScheme.light.primary,
+    disabledColor: FlexAppColorScheme.light.disabled,
+    scaffoldBackgroundColor: FlexAppColorScheme.light.scaffold,
     fontFamily: 'Roboto',
     textTheme: FlexTextTheme.lightTextTheme,
-    progressIndicatorTheme: const ProgressIndicatorThemeData(
-      color: FlexColors.primary,
+    progressIndicatorTheme: ProgressIndicatorThemeData(
+      color: FlexAppColorScheme.light.primary,
     ),
     elevatedButtonTheme: FlexElevatedButtonTheme.lightElevatedButtonTheme,
     outlinedButtonTheme: FlexOutlinedButtonTheme.lightOutlinedButtonTheme,
@@ -47,10 +53,12 @@ class FlexAppThemes {
     chipTheme: FlexChipTheme.lightChipTheme,
     inputDecorationTheme: FlexTextFormFieldTheme.lightInputDecorationTheme,
     searchBarTheme: SearchBarThemeData(
-      backgroundColor: WidgetStateColor.resolveWith((states) => Colors.white),
+      backgroundColor: WidgetStateColor.resolveWith(
+        (states) => FlexAppColorScheme.light.background,
+      ),
       elevation: const WidgetStatePropertyAll(0),
-      side: const WidgetStatePropertyAll(
-        BorderSide(color: FlexColors.primary),
+      side: WidgetStatePropertyAll(
+        BorderSide(color: FlexAppColorScheme.light.primary),
       ),
       shape: WidgetStateProperty.resolveWith(
         (states) => RoundedRectangleBorder(
@@ -62,28 +70,34 @@ class FlexAppThemes {
 
   static ThemeData darkTheme = ThemeData(
     useMaterial3: true,
-    appBarTheme: const AppBarTheme(
-      backgroundColor: Colors.transparent,
+    extensions: const [FlexAppColorScheme.dark],
+    appBarTheme: AppBarTheme(
+      backgroundColor: FlexAppColorScheme.dark.transparent,
       surfaceTintColor: Colors.transparent,
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
-      iconTheme: IconThemeData(color: Colors.black, size: FlexSizes.iconMd),
-      actionsIconTheme:
-          IconThemeData(color: Colors.black, size: FlexSizes.iconMd),
+      iconTheme: IconThemeData(
+        color: FlexAppColorScheme.dark.onPrimary,
+        size: FlexSizes.iconMd,
+      ),
+      actionsIconTheme: IconThemeData(
+        color: FlexAppColorScheme.dark.onPrimary,
+        size: FlexSizes.iconMd,
+      ),
       titleTextStyle: TextStyle(
         fontSize: FlexSizes.fontSizeXl,
         fontWeight: FontWeight.w600,
-        color: Colors.black,
+        color: FlexAppColorScheme.dark.onPrimary,
       ),
     ),
     brightness: Brightness.dark,
-    primaryColor: FlexColorsDark.primary,
-    disabledColor: FlexColorsDark.disabled,
-    scaffoldBackgroundColor: FlexColorsDark.scaffold,
+    primaryColor: FlexAppColorScheme.dark.primary,
+    disabledColor: FlexAppColorScheme.dark.disabled,
+    scaffoldBackgroundColor: FlexAppColorScheme.dark.scaffold,
     textTheme: FlexTextTheme.darkTextTheme,
-    progressIndicatorTheme: const ProgressIndicatorThemeData(
-      color: FlexColors.tertiary,
+    progressIndicatorTheme: ProgressIndicatorThemeData(
+      color: FlexAppColorScheme.dark.tertiary,
     ),
     elevatedButtonTheme: FlexElevatedButtonTheme.darkElevatedButtonTheme,
     outlinedButtonTheme: FlexOutlinedButtonTheme.darkOutlinedButtonTheme,
@@ -93,8 +107,8 @@ class FlexAppThemes {
     inputDecorationTheme: FlexTextFormFieldTheme.darkInputDecorationTheme,
     searchBarTheme: SearchBarThemeData(
       elevation: const WidgetStatePropertyAll(0),
-      side: const WidgetStatePropertyAll(
-        BorderSide(color: FlexColors.primary),
+      side: WidgetStatePropertyAll(
+        BorderSide(color: FlexAppColorScheme.dark.onPrimary),
       ),
       shape: WidgetStateProperty.resolveWith(
         (states) => RoundedRectangleBorder(

--- a/app/lib/theme/flex_app_themes.dart
+++ b/app/lib/theme/flex_app_themes.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 class FlexAppThemes {
   static ThemeData lightTheme = ThemeData(
     useMaterial3: true,
-    extensions: const [FlexAppColorScheme.light],
+    extensions: const [FlexAppColorScheme.lightScheme],
     appBarTheme: AppBarTheme(
       backgroundColor: Colors.transparent,
       surfaceTintColor: Colors.transparent,
@@ -20,31 +20,31 @@ class FlexAppThemes {
       scrolledUnderElevation: 0,
       centerTitle: false,
       iconTheme: IconThemeData(
-        color: FlexAppColorScheme.light.primary,
+        color: FlexAppColorScheme.lightScheme.primary,
         size: FlexSizes.iconMd,
       ),
       actionsIconTheme: IconThemeData(
-        color: FlexAppColorScheme.light.primary,
+        color: FlexAppColorScheme.lightScheme.primary,
         size: FlexSizes.iconMd,
       ),
       titleTextStyle: TextStyle(
         fontSize: FlexSizes.fontSizeXl,
         fontWeight: FontWeight.w600,
-        color: FlexAppColorScheme.light.primary,
+        color: FlexAppColorScheme.lightScheme.primary,
       ),
     ),
     brightness: Brightness.light,
     navigationBarTheme: NavigationBarThemeData(
-      backgroundColor: FlexAppColorScheme.light.primary.withOpacity(0.15),
-      indicatorColor: FlexAppColorScheme.light.secondary.withOpacity(0.1),
+      backgroundColor: FlexAppColorScheme.lightScheme.primary.withOpacity(0.15),
+      indicatorColor: FlexAppColorScheme.lightScheme.secondary.withOpacity(0.1),
     ),
-    primaryColor: FlexAppColorScheme.light.primary,
-    disabledColor: FlexAppColorScheme.light.disabled,
-    scaffoldBackgroundColor: FlexAppColorScheme.light.scaffold,
+    primaryColor: FlexAppColorScheme.lightScheme.primary,
+    disabledColor: FlexAppColorScheme.lightScheme.disabled,
+    scaffoldBackgroundColor: FlexAppColorScheme.lightScheme.scaffold,
     fontFamily: 'Roboto',
     textTheme: FlexTextTheme.lightTextTheme,
     progressIndicatorTheme: ProgressIndicatorThemeData(
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     elevatedButtonTheme: FlexElevatedButtonTheme.lightElevatedButtonTheme,
     outlinedButtonTheme: FlexOutlinedButtonTheme.lightOutlinedButtonTheme,
@@ -54,11 +54,11 @@ class FlexAppThemes {
     inputDecorationTheme: FlexTextFormFieldTheme.lightInputDecorationTheme,
     searchBarTheme: SearchBarThemeData(
       backgroundColor: WidgetStateColor.resolveWith(
-        (states) => FlexAppColorScheme.light.background,
+        (states) => FlexAppColorScheme.lightScheme.background,
       ),
       elevation: const WidgetStatePropertyAll(0),
       side: WidgetStatePropertyAll(
-        BorderSide(color: FlexAppColorScheme.light.primary),
+        BorderSide(color: FlexAppColorScheme.lightScheme.primary),
       ),
       shape: WidgetStateProperty.resolveWith(
         (states) => RoundedRectangleBorder(
@@ -70,34 +70,34 @@ class FlexAppThemes {
 
   static ThemeData darkTheme = ThemeData(
     useMaterial3: true,
-    extensions: const [FlexAppColorScheme.dark],
+    extensions: const [FlexAppColorScheme.darkScheme],
     appBarTheme: AppBarTheme(
-      backgroundColor: FlexAppColorScheme.dark.transparent,
+      backgroundColor: FlexAppColorScheme.darkScheme.transparent,
       surfaceTintColor: Colors.transparent,
       elevation: 0,
       scrolledUnderElevation: 0,
       centerTitle: false,
       iconTheme: IconThemeData(
-        color: FlexAppColorScheme.dark.onPrimary,
+        color: FlexAppColorScheme.darkScheme.onPrimary,
         size: FlexSizes.iconMd,
       ),
       actionsIconTheme: IconThemeData(
-        color: FlexAppColorScheme.dark.onPrimary,
+        color: FlexAppColorScheme.darkScheme.onPrimary,
         size: FlexSizes.iconMd,
       ),
       titleTextStyle: TextStyle(
         fontSize: FlexSizes.fontSizeXl,
         fontWeight: FontWeight.w600,
-        color: FlexAppColorScheme.dark.onPrimary,
+        color: FlexAppColorScheme.darkScheme.onPrimary,
       ),
     ),
     brightness: Brightness.dark,
-    primaryColor: FlexAppColorScheme.dark.primary,
-    disabledColor: FlexAppColorScheme.dark.disabled,
-    scaffoldBackgroundColor: FlexAppColorScheme.dark.scaffold,
+    primaryColor: FlexAppColorScheme.darkScheme.primary,
+    disabledColor: FlexAppColorScheme.darkScheme.disabled,
+    scaffoldBackgroundColor: FlexAppColorScheme.darkScheme.scaffold,
     textTheme: FlexTextTheme.darkTextTheme,
     progressIndicatorTheme: ProgressIndicatorThemeData(
-      color: FlexAppColorScheme.dark.tertiary,
+      color: FlexAppColorScheme.darkScheme.tertiary,
     ),
     elevatedButtonTheme: FlexElevatedButtonTheme.darkElevatedButtonTheme,
     outlinedButtonTheme: FlexOutlinedButtonTheme.darkOutlinedButtonTheme,
@@ -108,7 +108,7 @@ class FlexAppThemes {
     searchBarTheme: SearchBarThemeData(
       elevation: const WidgetStatePropertyAll(0),
       side: WidgetStatePropertyAll(
-        BorderSide(color: FlexAppColorScheme.dark.onPrimary),
+        BorderSide(color: FlexAppColorScheme.darkScheme.onPrimary),
       ),
       shape: WidgetStateProperty.resolveWith(
         (states) => RoundedRectangleBorder(

--- a/app/lib/theme/subthemes/chip_theme.dart
+++ b/app/lib/theme/subthemes/chip_theme.dart
@@ -1,21 +1,22 @@
+import 'package:flex_ui/flex_ui.dart';
 import 'package:flutter/material.dart';
 
 class FlexChipTheme {
   FlexChipTheme._();
 
   static ChipThemeData lightChipTheme = ChipThemeData(
-    disabledColor: Colors.grey.withOpacity(0.4),
+    disabledColor: FlexAppColorScheme.light.disabled.withOpacity(0.4),
     labelStyle: const TextStyle(color: Colors.black),
-    selectedColor: Colors.blue,
+    selectedColor: FlexAppColorScheme.light.info,
     padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
-    checkmarkColor: Colors.white,
+    checkmarkColor: FlexAppColorScheme.light.onPrimary,
   );
 
-  static ChipThemeData darkChipTheme = const ChipThemeData(
-    disabledColor: Colors.grey,
-    labelStyle: TextStyle(color: Colors.white),
-    selectedColor: Colors.blue,
-    padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
-    checkmarkColor: Colors.white,
+  static ChipThemeData darkChipTheme = ChipThemeData(
+    disabledColor: FlexAppColorScheme.dark.disabled,
+    labelStyle: const TextStyle(color: Colors.white),
+    selectedColor: FlexAppColorScheme.dark.info,
+    padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
+    checkmarkColor: FlexAppColorScheme.dark.primary,
   );
 }

--- a/app/lib/theme/subthemes/chip_theme.dart
+++ b/app/lib/theme/subthemes/chip_theme.dart
@@ -5,18 +5,18 @@ class FlexChipTheme {
   FlexChipTheme._();
 
   static ChipThemeData lightChipTheme = ChipThemeData(
-    disabledColor: FlexAppColorScheme.light.disabled.withOpacity(0.4),
+    disabledColor: FlexAppColorScheme.lightScheme.disabled.withOpacity(0.4),
     labelStyle: const TextStyle(color: Colors.black),
-    selectedColor: FlexAppColorScheme.light.info,
+    selectedColor: FlexAppColorScheme.lightScheme.info,
     padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
-    checkmarkColor: FlexAppColorScheme.light.onPrimary,
+    checkmarkColor: FlexAppColorScheme.lightScheme.onPrimary,
   );
 
   static ChipThemeData darkChipTheme = ChipThemeData(
-    disabledColor: FlexAppColorScheme.dark.disabled,
+    disabledColor: FlexAppColorScheme.darkScheme.disabled,
     labelStyle: const TextStyle(color: Colors.white),
-    selectedColor: FlexAppColorScheme.dark.info,
+    selectedColor: FlexAppColorScheme.darkScheme.info,
     padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
-    checkmarkColor: FlexAppColorScheme.dark.primary,
+    checkmarkColor: FlexAppColorScheme.darkScheme.primary,
   );
 }

--- a/app/lib/theme/subthemes/elevated_button_theme.dart
+++ b/app/lib/theme/subthemes/elevated_button_theme.dart
@@ -9,14 +9,14 @@ class FlexElevatedButtonTheme {
       ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
       elevation: 0,
-      foregroundColor: FlexColors.onPrimary,
-      backgroundColor: FlexColors.primary,
-      disabledForegroundColor: FlexColors.disabled,
-      disabledBackgroundColor: Colors.grey[300],
+      foregroundColor: FlexAppColorScheme.light.onPrimary,
+      backgroundColor: FlexAppColorScheme.light.primary,
+      disabledForegroundColor: FlexAppColorScheme.light.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.light.background,
       padding: const EdgeInsets.all(FlexSizes.lg),
-      textStyle: const TextStyle(
+      textStyle:  TextStyle(
         fontSize: FlexSizes.fontSizeSm,
-        color: FlexColors.onPrimary,
+        color: FlexAppColorScheme.light.onPrimary,
         fontWeight: FontWeight.w600,
       ),
       shape: RoundedRectangleBorder(
@@ -29,14 +29,14 @@ class FlexElevatedButtonTheme {
       ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
       elevation: 0,
-      foregroundColor: FlexColorsDark.onPrimary,
-      backgroundColor: FlexColorsDark.primary,
-      disabledForegroundColor: FlexColors.disabled,
-      disabledBackgroundColor: Colors.grey[300],
+      foregroundColor: FlexAppColorScheme.dark.onPrimary,
+      backgroundColor: FlexAppColorScheme.dark.primary,
+      disabledForegroundColor: FlexAppColorScheme.dark.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.dark.onBackground,
       padding: const EdgeInsets.all(FlexSizes.lg),
-      textStyle: const TextStyle(
+      textStyle:  TextStyle(
         fontSize: FlexSizes.fontSizeSm,
-        color: FlexColorsDark.onPrimary,
+        color: FlexAppColorScheme.dark.onPrimary,
         fontWeight: FontWeight.w600,
       ),
       shape: RoundedRectangleBorder(

--- a/app/lib/theme/subthemes/elevated_button_theme.dart
+++ b/app/lib/theme/subthemes/elevated_button_theme.dart
@@ -9,14 +9,14 @@ class FlexElevatedButtonTheme {
       ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
       elevation: 0,
-      foregroundColor: FlexAppColorScheme.light.onPrimary,
-      backgroundColor: FlexAppColorScheme.light.primary,
-      disabledForegroundColor: FlexAppColorScheme.light.disabled,
-      disabledBackgroundColor: FlexAppColorScheme.light.background,
+      foregroundColor: FlexAppColorScheme.lightScheme.onPrimary,
+      backgroundColor: FlexAppColorScheme.lightScheme.primary,
+      disabledForegroundColor: FlexAppColorScheme.lightScheme.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.lightScheme.background,
       padding: const EdgeInsets.all(FlexSizes.lg),
       textStyle:  TextStyle(
         fontSize: FlexSizes.fontSizeSm,
-        color: FlexAppColorScheme.light.onPrimary,
+        color: FlexAppColorScheme.lightScheme.onPrimary,
         fontWeight: FontWeight.w600,
       ),
       shape: RoundedRectangleBorder(
@@ -29,14 +29,14 @@ class FlexElevatedButtonTheme {
       ElevatedButtonThemeData(
     style: ElevatedButton.styleFrom(
       elevation: 0,
-      foregroundColor: FlexAppColorScheme.dark.onPrimary,
-      backgroundColor: FlexAppColorScheme.dark.primary,
-      disabledForegroundColor: FlexAppColorScheme.dark.disabled,
-      disabledBackgroundColor: FlexAppColorScheme.dark.onBackground,
+      foregroundColor: FlexAppColorScheme.darkScheme.onPrimary,
+      backgroundColor: FlexAppColorScheme.darkScheme.primary,
+      disabledForegroundColor: FlexAppColorScheme.darkScheme.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.darkScheme.onBackground,
       padding: const EdgeInsets.all(FlexSizes.lg),
       textStyle:  TextStyle(
         fontSize: FlexSizes.fontSizeSm,
-        color: FlexAppColorScheme.dark.onPrimary,
+        color: FlexAppColorScheme.darkScheme.onPrimary,
         fontWeight: FontWeight.w600,
       ),
       shape: RoundedRectangleBorder(

--- a/app/lib/theme/subthemes/icon_button_theme.dart
+++ b/app/lib/theme/subthemes/icon_button_theme.dart
@@ -8,11 +8,11 @@ class FlexIconButtonTheme {
   static IconButtonThemeData lightIconButtonTheme = IconButtonThemeData(
     style: IconButton.styleFrom(
       elevation: 1,
-      shadowColor: FlexAppColorScheme.light.primary,
-      foregroundColor: FlexAppColorScheme.light.primary,
-      backgroundColor: FlexAppColorScheme.light.onPrimary,
-      disabledForegroundColor: FlexAppColorScheme.light.disabled,
-      disabledBackgroundColor: FlexAppColorScheme.light.background,
+      shadowColor: FlexAppColorScheme.lightScheme.primary,
+      foregroundColor: FlexAppColorScheme.lightScheme.primary,
+      backgroundColor: FlexAppColorScheme.lightScheme.onPrimary,
+      disabledForegroundColor: FlexAppColorScheme.lightScheme.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.lightScheme.background,
       padding: const EdgeInsets.all(FlexSizes.xs),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(FlexSizes.borderRadiusSm),
@@ -23,11 +23,11 @@ class FlexIconButtonTheme {
   static IconButtonThemeData darkIconButtonTheme = IconButtonThemeData(
     style: IconButton.styleFrom(
       elevation: 1,
-      shadowColor: FlexAppColorScheme.dark.primary,
-      foregroundColor: FlexAppColorScheme.dark.onPrimary,
-      backgroundColor: FlexAppColorScheme.dark.primary,
-      disabledForegroundColor: FlexAppColorScheme.dark.disabled,
-      disabledBackgroundColor: FlexAppColorScheme.dark.onBackground,
+      shadowColor: FlexAppColorScheme.darkScheme.primary,
+      foregroundColor: FlexAppColorScheme.darkScheme.onPrimary,
+      backgroundColor: FlexAppColorScheme.darkScheme.primary,
+      disabledForegroundColor: FlexAppColorScheme.darkScheme.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.darkScheme.onBackground,
       padding: const EdgeInsets.all(FlexSizes.xs),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(FlexSizes.borderRadiusSm),

--- a/app/lib/theme/subthemes/icon_button_theme.dart
+++ b/app/lib/theme/subthemes/icon_button_theme.dart
@@ -7,31 +7,31 @@ class FlexIconButtonTheme {
 
   static IconButtonThemeData lightIconButtonTheme = IconButtonThemeData(
     style: IconButton.styleFrom(
-      elevation: 0,
-      foregroundColor: FlexColors.onPrimary,
-      backgroundColor: FlexColors.primary,
-      disabledForegroundColor: FlexColors.disabled,
-      disabledBackgroundColor: Colors.grey[300],
-      padding: const EdgeInsets.all(FlexSizes.lg),
+      elevation: 1,
+      shadowColor: FlexAppColorScheme.light.primary,
+      foregroundColor: FlexAppColorScheme.light.primary,
+      backgroundColor: FlexAppColorScheme.light.onPrimary,
+      disabledForegroundColor: FlexAppColorScheme.light.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.light.background,
+      padding: const EdgeInsets.all(FlexSizes.xs),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(FlexSizes.borderRadiusSm),
       ),
-      fixedSize: const Size.square(FlexSizes.buttonHeight),
     ),
   );
 
   static IconButtonThemeData darkIconButtonTheme = IconButtonThemeData(
     style: IconButton.styleFrom(
-      elevation: 0,
-      foregroundColor: FlexColorsDark.onPrimary,
-      backgroundColor: FlexColorsDark.primary,
-      disabledForegroundColor: FlexColors.disabled,
-      disabledBackgroundColor: Colors.grey[300],
-      padding: const EdgeInsets.all(FlexSizes.lg),
+      elevation: 1,
+      shadowColor: FlexAppColorScheme.dark.primary,
+      foregroundColor: FlexAppColorScheme.dark.onPrimary,
+      backgroundColor: FlexAppColorScheme.dark.primary,
+      disabledForegroundColor: FlexAppColorScheme.dark.disabled,
+      disabledBackgroundColor: FlexAppColorScheme.dark.onBackground,
+      padding: const EdgeInsets.all(FlexSizes.xs),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(FlexSizes.borderRadiusSm),
       ),
-      fixedSize: const Size.square(FlexSizes.buttonHeight),
     ),
   );
 }

--- a/app/lib/theme/subthemes/outlined_button_theme.dart
+++ b/app/lib/theme/subthemes/outlined_button_theme.dart
@@ -8,11 +8,11 @@ class FlexOutlinedButtonTheme {
       OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
       elevation: 0,
-      foregroundColor: FlexAppColorScheme.light.primary,
-      side: BorderSide(color: FlexAppColorScheme.light.info),
+      foregroundColor: FlexAppColorScheme.lightScheme.primary,
+      side: BorderSide(color: FlexAppColorScheme.lightScheme.info),
       textStyle: TextStyle(
         fontSize: 16,
-        color: FlexAppColorScheme.light.primary,
+        color: FlexAppColorScheme.lightScheme.primary,
         fontWeight: FontWeight.w600,
       ),
       padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
@@ -23,11 +23,11 @@ class FlexOutlinedButtonTheme {
   static OutlinedButtonThemeData darkOutlinedButtonTheme =
       OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
-      foregroundColor: FlexAppColorScheme.dark.primary,
-      side: BorderSide(color: FlexAppColorScheme.dark.info),
+      foregroundColor: FlexAppColorScheme.darkScheme.primary,
+      side: BorderSide(color: FlexAppColorScheme.darkScheme.info),
       textStyle: TextStyle(
         fontSize: 16,
-        color: FlexAppColorScheme.dark.primary,
+        color: FlexAppColorScheme.darkScheme.primary,
         fontWeight: FontWeight.w600,
       ),
       padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),

--- a/app/lib/theme/subthemes/outlined_button_theme.dart
+++ b/app/lib/theme/subthemes/outlined_button_theme.dart
@@ -1,3 +1,4 @@
+import 'package:flex_ui/tokens/colors.dart';
 import 'package:flutter/material.dart';
 
 class FlexOutlinedButtonTheme {
@@ -7,11 +8,11 @@ class FlexOutlinedButtonTheme {
       OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
       elevation: 0,
-      foregroundColor: Colors.black,
-      side: const BorderSide(color: Colors.blue),
-      textStyle: const TextStyle(
+      foregroundColor: FlexAppColorScheme.light.primary,
+      side: BorderSide(color: FlexAppColorScheme.light.info),
+      textStyle: TextStyle(
         fontSize: 16,
-        color: Colors.black,
+        color: FlexAppColorScheme.light.primary,
         fontWeight: FontWeight.w600,
       ),
       padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
@@ -22,11 +23,11 @@ class FlexOutlinedButtonTheme {
   static OutlinedButtonThemeData darkOutlinedButtonTheme =
       OutlinedButtonThemeData(
     style: OutlinedButton.styleFrom(
-      foregroundColor: Colors.white,
-      side: const BorderSide(color: Colors.blueAccent),
-      textStyle: const TextStyle(
+      foregroundColor: FlexAppColorScheme.dark.primary,
+      side: BorderSide(color: FlexAppColorScheme.dark.info),
+      textStyle: TextStyle(
         fontSize: 16,
-        color: Colors.white,
+        color: FlexAppColorScheme.dark.primary,
         fontWeight: FontWeight.w600,
       ),
       padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),

--- a/app/lib/theme/subthemes/text_field_theme.dart
+++ b/app/lib/theme/subthemes/text_field_theme.dart
@@ -1,3 +1,4 @@
+import 'package:flex_ui/tokens/colors.dart';
 import 'package:flutter/material.dart';
 
 class FlexTextFormFieldTheme {
@@ -5,63 +6,67 @@ class FlexTextFormFieldTheme {
 
   static InputDecorationTheme lightInputDecorationTheme = InputDecorationTheme(
     errorMaxLines: 3,
-    prefixIconColor: Colors.grey,
-    suffixIconColor: Colors.grey,
-    labelStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.black),
-    hintStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.black),
+    prefixIconColor: FlexAppColorScheme.light.disabled,
+    suffixIconColor: FlexAppColorScheme.light.disabled,
+    labelStyle: const TextStyle()
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.light.primary),
+    hintStyle: const TextStyle()
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.light.primary),
     errorStyle: const TextStyle().copyWith(fontStyle: FontStyle.normal),
-    floatingLabelStyle:
-        const TextStyle().copyWith(color: Colors.black.withOpacity(0.8)),
+    floatingLabelStyle: const TextStyle()
+        .copyWith(color: FlexAppColorScheme.light.primary.withOpacity(0.8)),
     border: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.grey),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.disabled),
     ),
     enabledBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.grey),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.disabled),
     ),
     focusedBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.black12),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.primary),
     ),
     errorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.red),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.error),
     ),
     focusedErrorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 2, color: Colors.orange),
+      borderSide: BorderSide(width: 2, color: FlexAppColorScheme.light.warning),
     ),
   );
 
   static InputDecorationTheme darkInputDecorationTheme = InputDecorationTheme(
     errorMaxLines: 3,
-    prefixIconColor: Colors.grey,
-    suffixIconColor: Colors.grey,
-    labelStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.white),
-    hintStyle: const TextStyle().copyWith(fontSize: 14, color: Colors.white),
+    prefixIconColor: FlexAppColorScheme.dark.disabled,
+    suffixIconColor: FlexAppColorScheme.dark.disabled,
+    labelStyle: const TextStyle()
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.dark.primary),
+    hintStyle: const TextStyle()
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.dark.primary),
     errorStyle: const TextStyle().copyWith(fontStyle: FontStyle.normal),
-    floatingLabelStyle:
-        const TextStyle().copyWith(color: Colors.white.withOpacity(0.8)),
+    floatingLabelStyle: const TextStyle()
+        .copyWith(color: FlexAppColorScheme.dark.primary.withOpacity(0.8)),
     border: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.grey),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.disabled),
     ),
     enabledBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.grey),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.disabled),
     ),
     focusedBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.white),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.primary),
     ),
     errorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 1, color: Colors.red),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.error),
     ),
     focusedErrorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: const BorderSide(width: 2, color: Colors.orange),
+      borderSide: BorderSide(width: 2, color: FlexAppColorScheme.dark.warning),
     ),
   );
 }

--- a/app/lib/theme/subthemes/text_field_theme.dart
+++ b/app/lib/theme/subthemes/text_field_theme.dart
@@ -6,67 +6,67 @@ class FlexTextFormFieldTheme {
 
   static InputDecorationTheme lightInputDecorationTheme = InputDecorationTheme(
     errorMaxLines: 3,
-    prefixIconColor: FlexAppColorScheme.light.disabled,
-    suffixIconColor: FlexAppColorScheme.light.disabled,
+    prefixIconColor: FlexAppColorScheme.lightScheme.disabled,
+    suffixIconColor: FlexAppColorScheme.lightScheme.disabled,
     labelStyle: const TextStyle()
-        .copyWith(fontSize: 14, color: FlexAppColorScheme.light.primary),
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.lightScheme.primary),
     hintStyle: const TextStyle()
-        .copyWith(fontSize: 14, color: FlexAppColorScheme.light.primary),
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.lightScheme.primary),
     errorStyle: const TextStyle().copyWith(fontStyle: FontStyle.normal),
     floatingLabelStyle: const TextStyle()
-        .copyWith(color: FlexAppColorScheme.light.primary.withOpacity(0.8)),
+        .copyWith(color: FlexAppColorScheme.lightScheme.primary.withOpacity(0.8)),
     border: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.disabled),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.lightScheme.disabled),
     ),
     enabledBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.disabled),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.lightScheme.disabled),
     ),
     focusedBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.primary),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.lightScheme.primary),
     ),
     errorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.light.error),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.lightScheme.error),
     ),
     focusedErrorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 2, color: FlexAppColorScheme.light.warning),
+      borderSide: BorderSide(width: 2, color: FlexAppColorScheme.lightScheme.warning),
     ),
   );
 
   static InputDecorationTheme darkInputDecorationTheme = InputDecorationTheme(
     errorMaxLines: 3,
-    prefixIconColor: FlexAppColorScheme.dark.disabled,
-    suffixIconColor: FlexAppColorScheme.dark.disabled,
+    prefixIconColor: FlexAppColorScheme.darkScheme.disabled,
+    suffixIconColor: FlexAppColorScheme.darkScheme.disabled,
     labelStyle: const TextStyle()
-        .copyWith(fontSize: 14, color: FlexAppColorScheme.dark.primary),
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.darkScheme.primary),
     hintStyle: const TextStyle()
-        .copyWith(fontSize: 14, color: FlexAppColorScheme.dark.primary),
+        .copyWith(fontSize: 14, color: FlexAppColorScheme.darkScheme.primary),
     errorStyle: const TextStyle().copyWith(fontStyle: FontStyle.normal),
     floatingLabelStyle: const TextStyle()
-        .copyWith(color: FlexAppColorScheme.dark.primary.withOpacity(0.8)),
+        .copyWith(color: FlexAppColorScheme.darkScheme.primary.withOpacity(0.8)),
     border: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.disabled),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.darkScheme.disabled),
     ),
     enabledBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.disabled),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.darkScheme.disabled),
     ),
     focusedBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.primary),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.darkScheme.primary),
     ),
     errorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.dark.error),
+      borderSide: BorderSide(width: 1, color: FlexAppColorScheme.darkScheme.error),
     ),
     focusedErrorBorder: const OutlineInputBorder().copyWith(
       borderRadius: BorderRadius.circular(14),
-      borderSide: BorderSide(width: 2, color: FlexAppColorScheme.dark.warning),
+      borderSide: BorderSide(width: 2, color: FlexAppColorScheme.darkScheme.warning),
     ),
   );
 }

--- a/app/lib/theme/subthemes/text_theme.dart
+++ b/app/lib/theme/subthemes/text_theme.dart
@@ -8,57 +8,57 @@ class FlexTextTheme {
     headlineLarge: const TextStyle().copyWith(
       fontSize: 32.0,
       fontWeight: FontWeight.bold,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     headlineMedium: const TextStyle().copyWith(
       fontSize: 24.0,
       fontWeight: FontWeight.w600,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     headlineSmall: const TextStyle().copyWith(
       fontSize: 18.0,
       fontWeight: FontWeight.w600,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     titleLarge: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w600,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     titleMedium: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w500,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     titleSmall: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w400,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     bodyLarge: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     bodyMedium: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     bodySmall: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.light.primary.withOpacity(0.5),
+      color: FlexAppColorScheme.lightScheme.primary.withOpacity(0.5),
     ),
     labelLarge: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.light.primary,
+      color: FlexAppColorScheme.lightScheme.primary,
     ),
     labelSmall: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.light.primary.withOpacity(0.5),
+      color: FlexAppColorScheme.lightScheme.primary.withOpacity(0.5),
     ),
   );
 
@@ -66,57 +66,57 @@ class FlexTextTheme {
     headlineLarge: const TextStyle().copyWith(
       fontSize: 32.0,
       fontWeight: FontWeight.bold,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     headlineMedium: const TextStyle().copyWith(
       fontSize: 24.0,
       fontWeight: FontWeight.w600,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     headlineSmall: const TextStyle().copyWith(
       fontSize: 18.0,
       fontWeight: FontWeight.w600,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     titleLarge: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w600,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     titleMedium: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w500,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     titleSmall: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w400,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     bodyLarge: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     bodyMedium: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     bodySmall: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.dark.primary.withOpacity(0.5),
+      color: FlexAppColorScheme.darkScheme.primary.withOpacity(0.5),
     ),
     labelLarge: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.dark.primary,
+      color: FlexAppColorScheme.darkScheme.primary,
     ),
     labelSmall: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: FlexAppColorScheme.dark.primary.withOpacity(0.5),
+      color: FlexAppColorScheme.darkScheme.primary.withOpacity(0.5),
     ),
   );
 }

--- a/app/lib/theme/subthemes/text_theme.dart
+++ b/app/lib/theme/subthemes/text_theme.dart
@@ -1,3 +1,4 @@
+import 'package:flex_ui/tokens/colors.dart';
 import 'package:flutter/material.dart';
 
 class FlexTextTheme {
@@ -7,57 +8,57 @@ class FlexTextTheme {
     headlineLarge: const TextStyle().copyWith(
       fontSize: 32.0,
       fontWeight: FontWeight.bold,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     headlineMedium: const TextStyle().copyWith(
       fontSize: 24.0,
       fontWeight: FontWeight.w600,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     headlineSmall: const TextStyle().copyWith(
       fontSize: 18.0,
       fontWeight: FontWeight.w600,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     titleLarge: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w600,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     titleMedium: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w500,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     titleSmall: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w400,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     bodyLarge: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     bodyMedium: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     bodySmall: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: Colors.black.withOpacity(0.5),
+      color: FlexAppColorScheme.light.primary.withOpacity(0.5),
     ),
     labelLarge: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: Colors.black,
+      color: FlexAppColorScheme.light.primary,
     ),
     labelSmall: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: Colors.black.withOpacity(0.5),
+      color: FlexAppColorScheme.light.primary.withOpacity(0.5),
     ),
   );
 
@@ -65,57 +66,57 @@ class FlexTextTheme {
     headlineLarge: const TextStyle().copyWith(
       fontSize: 32.0,
       fontWeight: FontWeight.bold,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     headlineMedium: const TextStyle().copyWith(
       fontSize: 24.0,
       fontWeight: FontWeight.w600,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     headlineSmall: const TextStyle().copyWith(
       fontSize: 18.0,
       fontWeight: FontWeight.w600,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     titleLarge: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w600,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     titleMedium: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w500,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     titleSmall: const TextStyle().copyWith(
       fontSize: 16.0,
       fontWeight: FontWeight.w400,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     bodyLarge: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     bodyMedium: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     bodySmall: const TextStyle().copyWith(
       fontSize: 14.0,
       fontWeight: FontWeight.normal,
-      color: Colors.white.withOpacity(0.5),
+      color: FlexAppColorScheme.dark.primary.withOpacity(0.5),
     ),
     labelLarge: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: Colors.white,
+      color: FlexAppColorScheme.dark.primary,
     ),
     labelSmall: const TextStyle().copyWith(
       fontSize: 12.0,
       fontWeight: FontWeight.normal,
-      color: Colors.white.withOpacity(0.5),
+      color: FlexAppColorScheme.dark.primary.withOpacity(0.5),
     ),
   );
 }

--- a/app/lib/tokens/colors.dart
+++ b/app/lib/tokens/colors.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 
 /// [FlexAppColorScheme] contains all colors used in the application
 /// It's a theme extension so it can be used in [ThemeData], extensions attribut
-/// [light] and [dark] are getter to get access to custom colors
+/// [lightScheme] and [darkScheme] are getter to get access to custom colors
 /// More info on this article : https://medium.com/@alexandersnotes/flutter-custom-theme-with-themeextension-792034106abc
 class FlexAppColorScheme extends ThemeExtension<FlexAppColorScheme> {
   final Color primary;
@@ -29,12 +29,6 @@ class FlexAppColorScheme extends ThemeExtension<FlexAppColorScheme> {
   final Color onDisabled;
   final Color transparent;
 
-  // information colors
-  static const info = Color.fromRGBO(0, 122, 255, 1.0);
-  static const success = Color.fromRGBO(34, 174, 69, 1);
-  static const warning = Color.fromRGBO(255, 149, 0, 1.0);
-  static const error = Color.fromRGBO(255, 59, 48, 1.0);
-  static const disabled = Color.fromRGBO(142, 142, 147, 1.0);
   const FlexAppColorScheme({
     required this.primary,
     required this.onPrimary,
@@ -146,7 +140,7 @@ class FlexAppColorScheme extends ThemeExtension<FlexAppColorScheme> {
     );
   }
 
-  static const light = FlexAppColorScheme(
+  static const lightScheme = FlexAppColorScheme(
     primary: Color.fromRGBO(34, 34, 34, 1),
     onPrimary: Color.fromRGBO(250, 250, 250, 1),
     secondary: Color.fromRGBO(36, 55, 254, 1),
@@ -172,7 +166,7 @@ class FlexAppColorScheme extends ThemeExtension<FlexAppColorScheme> {
     transparent: Colors.transparent,
   );
 
-  static const dark = FlexAppColorScheme(
+  static const darkScheme = FlexAppColorScheme(
     primary: Color.fromRGBO(250, 250, 250, 1),
     onPrimary: Color.fromRGBO(34, 34, 34, 1),
     secondary: Color.fromRGBO(36, 55, 254, 1),

--- a/app/lib/tokens/colors.dart
+++ b/app/lib/tokens/colors.dart
@@ -1,50 +1,33 @@
 import 'package:flutter/material.dart';
 
-class FlexColors {
-  // brand colors
-  static const primary = Color.fromRGBO(34, 34, 34, 1);
-  static const secondary = Color.fromRGBO(36, 55, 254, 1);
-  static const tertiary = Color.fromRGBO(241, 255, 97, 1);
-
-  static const onPrimary = Color.fromRGBO(250, 250, 250, 1);
-  static const onSecondary = Color.fromRGBO(250, 250, 250, 1);
-  static const onTertiary = primary;
-
-  // app colors
-  static const divider = Color.fromRGBO(230, 230, 230, 1);
-  static const scaffold = Color.fromRGBO(255, 255, 255, 1);
-
-  // information colors
-  static const info = Color.fromRGBO(0, 122, 255, 1.0);
-  static const success = Color.fromRGBO(34, 174, 69, 1);
-  static const warning = Color.fromRGBO(255, 149, 0, 1.0);
-  static const error = Color.fromRGBO(255, 59, 48, 1.0);
-  static const disabled = Color.fromRGBO(142, 142, 147, 1.0);
-
-  static const onInfo = Color.fromRGBO(250, 250, 250, 1);
-  static const onSuccess = Color.fromRGBO(250, 250, 250, 1);
-  static const onWarning = Color.fromRGBO(250, 250, 250, 1);
-  static const onError = Color.fromRGBO(250, 250, 250, 1);
-  static const onDisabled = Color.fromRGBO(250, 250, 250, 1);
-
-  // button colors
-  static const shadow = Color.fromRGBO(0, 0, 0, 1);
-  static const background = Color.fromRGBO(255, 255, 255, 1);
-}
-
-class FlexColorsDark {
-  // brand colors
-  static const primary = Color.fromRGBO(250, 250, 250, 1);
-  static const secondary = Color.fromRGBO(36, 55, 254, 1);
-  static const tertiary = Color.fromRGBO(241, 255, 97, 1);
-
-  static const onPrimary = Color.fromRGBO(34, 34, 34, 1);
-  static const onSecondary = Color.fromRGBO(250, 250, 250, 1);
-  static const onTertiary = primary;
-
-  // app colors
-  static const divider = Color.fromRGBO(230, 230, 230, 1);
-  static const scaffold = Color.fromRGBO(34, 34, 34, 1);
+/// [FlexAppColorScheme] contains all colors used in the application
+/// It's a theme extension so it can be used in [ThemeData], extensions attribut
+/// [light] and [dark] are getter to get access to custom colors
+/// More info on this article : https://medium.com/@alexandersnotes/flutter-custom-theme-with-themeextension-792034106abc
+class FlexAppColorScheme extends ThemeExtension<FlexAppColorScheme> {
+  final Color primary;
+  final Color onPrimary;
+  final Color secondary;
+  final Color onSecondary;
+  final Color tertiary;
+  final Color onTertiary;
+  final Color error;
+  final Color onError;
+  final Color background;
+  final Color onBackground;
+  final Color surface;
+  final Color onSurface;
+  final Color divider;
+  final Color scaffold;
+  final Color info;
+  final Color onInfo;
+  final Color success;
+  final Color onSuccess;
+  final Color warning;
+  final Color onWarning;
+  final Color disabled;
+  final Color onDisabled;
+  final Color transparent;
 
   // information colors
   static const info = Color.fromRGBO(0, 122, 255, 1.0);
@@ -52,14 +35,166 @@ class FlexColorsDark {
   static const warning = Color.fromRGBO(255, 149, 0, 1.0);
   static const error = Color.fromRGBO(255, 59, 48, 1.0);
   static const disabled = Color.fromRGBO(142, 142, 147, 1.0);
+  const FlexAppColorScheme({
+    required this.primary,
+    required this.onPrimary,
+    required this.secondary,
+    required this.onSecondary,
+    required this.tertiary,
+    required this.onTertiary,
+    required this.error,
+    required this.onError,
+    required this.background,
+    required this.onBackground,
+    required this.surface,
+    required this.onSurface,
+    required this.divider,
+    required this.scaffold,
+    required this.info,
+    required this.onInfo,
+    required this.success,
+    required this.onSuccess,
+    required this.warning,
+    required this.onWarning,
+    required this.disabled,
+    required this.onDisabled,
+    required this.transparent,
+  });
 
-  static const onInfo = Color.fromRGBO(250, 250, 250, 1);
-  static const onSuccess = Color.fromRGBO(250, 250, 250, 1);
-  static const onWarning = Color.fromRGBO(250, 250, 250, 1);
-  static const onError = Color.fromRGBO(250, 250, 250, 1);
-  static const onDisabled = Color.fromRGBO(250, 250, 250, 1);
+  @override
+  FlexAppColorScheme copyWith({
+    Color? primary,
+    Color? onPrimary,
+    Color? secondary,
+    Color? onSecondary,
+    Color? tertiary,
+    Color? onTertiary,
+    Color? error,
+    Color? onError,
+    Color? background,
+    Color? onBackground,
+    Color? surface,
+    Color? onSurface,
+    Color? divider,
+    Color? scaffold,
+    Color? info,
+    Color? onInfo,
+    Color? success,
+    Color? onSuccess,
+    Color? warning,
+    Color? onWarning,
+    Color? disabled,
+    Color? onDisabled,
+    Color? transparent,
+  }) {
+    return FlexAppColorScheme(
+      primary: primary ?? this.primary,
+      onPrimary: onPrimary ?? this.onPrimary,
+      secondary: secondary ?? this.secondary,
+      onSecondary: onSecondary ?? this.onSecondary,
+      tertiary: tertiary ?? this.tertiary,
+      onTertiary: onTertiary ?? this.onTertiary,
+      error: error ?? this.error,
+      onError: onError ?? this.onError,
+      background: background ?? this.background,
+      onBackground: onBackground ?? this.onBackground,
+      surface: surface ?? this.surface,
+      onSurface: onSurface ?? this.onSurface,
+      divider: divider ?? this.divider,
+      scaffold: scaffold ?? this.scaffold,
+      info: info ?? this.info,
+      onInfo: onInfo ?? this.onInfo,
+      success: success ?? this.success,
+      onSuccess: onSuccess ?? this.onSuccess,
+      warning: warning ?? this.warning,
+      onWarning: onWarning ?? this.onWarning,
+      disabled: disabled ?? this.disabled,
+      onDisabled: onDisabled ?? this.onDisabled,
+      transparent: transparent ?? this.transparent,
+    );
+  }
 
-  // button colors
-  static const shadow = Color.fromRGBO(0, 0, 0, 1);
-  static const background = Color.fromRGBO(34, 34, 34, 1);
+  @override
+  FlexAppColorScheme lerp(ThemeExtension<FlexAppColorScheme>? other, double t) {
+    if (other is! FlexAppColorScheme) {
+      return this;
+    }
+    return FlexAppColorScheme(
+      primary: Color.lerp(primary, other.primary, t)!,
+      onPrimary: Color.lerp(onPrimary, other.onPrimary, t)!,
+      secondary: Color.lerp(secondary, other.secondary, t)!,
+      onSecondary: Color.lerp(onSecondary, other.onSecondary, t)!,
+      tertiary: Color.lerp(tertiary, other.tertiary, t)!,
+      onTertiary: Color.lerp(onTertiary, other.onTertiary, t)!,
+      error: Color.lerp(error, other.error, t)!,
+      onError: Color.lerp(onError, other.onError, t)!,
+      background: Color.lerp(background, other.background, t)!,
+      onBackground: Color.lerp(onBackground, other.onBackground, t)!,
+      surface: Color.lerp(surface, other.surface, t)!,
+      onSurface: Color.lerp(onSurface, other.onSurface, t)!,
+      divider: Color.lerp(divider, other.divider, t)!,
+      scaffold: Color.lerp(scaffold, other.scaffold, t)!,
+      info: Color.lerp(info, other.info, t)!,
+      onInfo: Color.lerp(onInfo, other.onInfo, t)!,
+      success: Color.lerp(success, other.success, t)!,
+      onSuccess: Color.lerp(onSuccess, other.onSuccess, t)!,
+      warning: Color.lerp(warning, other.warning, t)!,
+      onWarning: Color.lerp(onWarning, other.onWarning, t)!,
+      disabled: Color.lerp(disabled, other.disabled, t)!,
+      onDisabled: Color.lerp(onDisabled, other.onDisabled, t)!,
+      transparent: Color.lerp(transparent, other.transparent, t)!,
+    );
+  }
+
+  static const light = FlexAppColorScheme(
+    primary: Color.fromRGBO(34, 34, 34, 1),
+    onPrimary: Color.fromRGBO(250, 250, 250, 1),
+    secondary: Color.fromRGBO(36, 55, 254, 1),
+    onSecondary: Color.fromRGBO(250, 250, 250, 1),
+    tertiary: Color.fromRGBO(241, 255, 97, 1),
+    onTertiary: Color.fromRGBO(34, 34, 34, 1),
+    error: Color.fromRGBO(255, 59, 48, 1.0),
+    onError: Color.fromRGBO(250, 250, 250, 1),
+    background: Color.fromRGBO(255, 255, 255, 1),
+    onBackground: Color.fromRGBO(34, 34, 34, 1),
+    surface: Color.fromRGBO(255, 255, 255, 1),
+    onSurface: Color.fromRGBO(34, 34, 34, 1),
+    divider: Color.fromRGBO(230, 230, 230, 1),
+    scaffold: Color.fromRGBO(255, 255, 255, 1),
+    info: Color.fromRGBO(0, 122, 255, 1.0),
+    onInfo: Color.fromRGBO(250, 250, 250, 1),
+    success: Color.fromRGBO(34, 174, 69, 1),
+    onSuccess: Color.fromRGBO(250, 250, 250, 1),
+    warning: Color.fromRGBO(255, 149, 0, 1.0),
+    onWarning: Color.fromRGBO(250, 250, 250, 1),
+    disabled: Color.fromRGBO(142, 142, 147, 1.0),
+    onDisabled: Color.fromRGBO(250, 250, 250, 1),
+    transparent: Colors.transparent,
+  );
+
+  static const dark = FlexAppColorScheme(
+    primary: Color.fromRGBO(250, 250, 250, 1),
+    onPrimary: Color.fromRGBO(34, 34, 34, 1),
+    secondary: Color.fromRGBO(36, 55, 254, 1),
+    onSecondary: Color.fromRGBO(250, 250, 250, 1),
+    tertiary: Color.fromRGBO(241, 255, 97, 1),
+    onTertiary: Color.fromRGBO(250, 250, 250, 1),
+    error: Color.fromRGBO(255, 59, 48, 1.0),
+    onError: Color.fromRGBO(250, 250, 250, 1),
+    background: Color.fromRGBO(34, 34, 34, 1),
+    onBackground: Color.fromRGBO(250, 250, 250, 1),
+    surface: Color.fromRGBO(34, 34, 34, 1),
+    onSurface: Color.fromRGBO(250, 250, 250, 1),
+    divider: Color.fromRGBO(230, 230, 230, 1),
+    scaffold: Color.fromRGBO(34, 34, 34, 1),
+    info: Color.fromRGBO(0, 122, 255, 1.0),
+    onInfo: Color.fromRGBO(250, 250, 250, 1),
+    success: Color.fromRGBO(34, 174, 69, 1),
+    onSuccess: Color.fromRGBO(250, 250, 250, 1),
+    warning: Color.fromRGBO(255, 149, 0, 1.0),
+    onWarning: Color.fromRGBO(250, 250, 250, 1),
+    disabled: Color.fromRGBO(142, 142, 147, 1.0),
+    onDisabled: Color.fromRGBO(250, 250, 250, 1),
+    transparent: Colors.transparent,
+  );
 }

--- a/app/lib/utils/extensions.dart
+++ b/app/lib/utils/extensions.dart
@@ -1,20 +1,22 @@
+import 'package:flex_ui/tokens/colors.dart';
 import 'package:flutter/material.dart';
 
 extension StringExtension on String? {
   bool isNotBlank() => this?.trim().isNotEmpty ?? false;
 }
 
-extension BuildContextExtensions on BuildContext {
-  ThemeData get _theme => Theme.of(this);
-  TextTheme get textTheme => _theme.textTheme;
-  ColorScheme get colorScheme => _theme.colorScheme;
   Size get deviceSize => MediaQuery.sizeOf(this);
-
-  // additional helpful getters
   double get screenWidth => deviceSize.width;
   double get screenHeight => deviceSize.height;
   EdgeInsets get padding => MediaQuery.paddingOf(this);
   bool get isDarkMode =>
       MediaQuery.platformBrightnessOf(this) == Brightness.dark;
   bool get isKeyboardVisible => MediaQuery.viewInsetsOf(this).bottom > 0;
+/// SugarSyntax to get access quickly to [ThemeData],[TextTheme] and [FlexAppColorScheme] from context
+extension ThemeExtension on BuildContext {
+  ThemeData get theme => Theme.of(this);
+  TextTheme get textTheme => Theme.of(this).textTheme;
+  FlexAppColorScheme get colors => Theme.of(this).extension<FlexAppColorScheme>()!;
+  // additional helpful getters
+
 }

--- a/app/lib/utils/extensions.dart
+++ b/app/lib/utils/extensions.dart
@@ -5,6 +5,15 @@ extension StringExtension on String? {
   bool isNotBlank() => this?.trim().isNotEmpty ?? false;
 }
 
+/// SugarSyntax to get access quickly to [ThemeData],[TextTheme] and [FlexAppColorScheme] from context
+extension ThemeExtension on BuildContext {
+  ThemeData get theme => Theme.of(this);
+  TextTheme get textTheme => Theme.of(this).textTheme;
+  FlexAppColorScheme get colors =>
+      Theme.of(this).extension<FlexAppColorScheme>()!;
+
+  // additional helpful getters
+
   Size get deviceSize => MediaQuery.sizeOf(this);
   double get screenWidth => deviceSize.width;
   double get screenHeight => deviceSize.height;
@@ -12,11 +21,4 @@ extension StringExtension on String? {
   bool get isDarkMode =>
       MediaQuery.platformBrightnessOf(this) == Brightness.dark;
   bool get isKeyboardVisible => MediaQuery.viewInsetsOf(this).bottom > 0;
-/// SugarSyntax to get access quickly to [ThemeData],[TextTheme] and [FlexAppColorScheme] from context
-extension ThemeExtension on BuildContext {
-  ThemeData get theme => Theme.of(this);
-  TextTheme get textTheme => Theme.of(this).textTheme;
-  FlexAppColorScheme get colors => Theme.of(this).extension<FlexAppColorScheme>()!;
-  // additional helpful getters
-
 }

--- a/app/lib/widgets/app_bar/app_bar.dart
+++ b/app/lib/widgets/app_bar/app_bar.dart
@@ -5,9 +5,9 @@ import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 
 /// [FlexAppBar] is a flex implementation of [AppBar].
-/// 
+///
 /// [LeadingIcon] and [TrailingIcon] are IconData with their owns onPressed function.
-/// 
+///
 /// If you provide an Icon, you must provide his onPressed function.
 class FlexAppBar extends StatelessWidget implements PreferredSizeWidget {
   const FlexAppBar({
@@ -36,21 +36,11 @@ class FlexAppBar extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   Widget build(BuildContext context) {
-    final brightness = Theme.of(context).brightness;
-    final iconButtonStyle = Theme.of(context).iconButtonTheme.style?.copyWith(
-          backgroundColor: const WidgetStatePropertyAll(Colors.transparent),
-          iconColor: WidgetStatePropertyAll(
-            brightness == Brightness.dark ? Colors.white : Colors.black,
-          ),
-          padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-        );
-
     return AppBar(
       automaticallyImplyLeading: false,
       centerTitle: centerTitle,
       leading: leadingIcon != null
           ? IconButton(
-              style: iconButtonStyle,
               onPressed: onLeadingIconPressed,
               icon: Icon(leadingIcon),
             )
@@ -59,7 +49,6 @@ class FlexAppBar extends StatelessWidget implements PreferredSizeWidget {
       actions: [
         if (trailingIcon != null)
           IconButton(
-            style: iconButtonStyle,
             onPressed: onTrailingIconPressed,
             icon: Icon(trailingIcon),
           ),

--- a/app/lib/widgets/cards/productCard/content_product_card.dart
+++ b/app/lib/widgets/cards/productCard/content_product_card.dart
@@ -1,5 +1,5 @@
 import 'package:flex_ui/tokens/sizes.dart';
-import 'package:flex_ui/widgets/cards/productCard/shared/product_infos.dart';
+import 'package:flex_ui/widgets/cards/productCard/shared/product_info.dart';
 import 'package:flex_ui/widgets/image/image.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/widgets/cards/productCard/product_card.dart
+++ b/app/lib/widgets/cards/productCard/product_card.dart
@@ -1,4 +1,5 @@
-import 'package:flex_ui/flex_ui.dart';
+import 'package:flex_ui/tokens/sizes.dart';
+import 'package:flex_ui/utils/extensions.dart';
 import 'package:flex_ui/widgets/cards/productCard/content_product_card.dart';
 import 'package:flex_ui/widgets/cards/productCard/shared/right_bottom_icon_button.dart';
 import 'package:flex_ui/widgets/cards/productCard/shared/left_top_icon.dart';
@@ -124,23 +125,6 @@ Widget standardFlexProductCard(BuildContext context) {
   final bool isSaved =
       context.knobs.boolean(label: 'isProductSaved', initialValue: false);
 
-  final brightness = Theme.of(context).brightness;
-
-  final iconButtonStyle = Theme.of(context).iconButtonTheme.style?.copyWith(
-        elevation: const WidgetStatePropertyAll(1),
-        shadowColor: brightness == Brightness.light
-            ? const WidgetStatePropertyAll(FlexColors.shadow)
-            : const WidgetStatePropertyAll(FlexColorsDark.shadow),
-        backgroundColor: brightness == Brightness.light
-            ? const WidgetStatePropertyAll(FlexColors.background)
-            : const WidgetStatePropertyAll(FlexColorsDark.background),
-        iconColor: WidgetStatePropertyAll(
-            isSaved ? FlexColors.secondary : FlexColors.disabled),
-        padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-        fixedSize: const WidgetStatePropertyAll(Size.zero),
-        shape: const WidgetStatePropertyAll(StadiumBorder()),
-      );
-
   return Center(
     child: Container(
       height: 400,
@@ -161,7 +145,7 @@ Widget standardFlexProductCard(BuildContext context) {
             .boolean(label: 'displayLeftIcon', initialValue: false),
         leftIconLabel: 'New',
         leftIconSemanticsLabel: 'This is a new product',
-        leftIconBackgroundColor: FlexColors.secondary,
+        leftIconBackgroundColor: context.colors.info,
         leftIconTextColor: Colors.white,
         displayRightIcon: context.knobs
             .boolean(label: 'displayRightIcon', initialValue: false),
@@ -169,7 +153,6 @@ Widget standardFlexProductCard(BuildContext context) {
         rightIcon: isSaved
             ? const Icon(Icons.bookmark)
             : const Icon(Icons.bookmark_outline),
-        rightIconButtonStyle: iconButtonStyle,
         rightIconSemanticsLabel: isSaved
             ? 'Tap on this button to remove the product from your wishlist'
             : 'Tap on this button to add the product to your wishlist',

--- a/app/lib/widgets/cards/productCard/shared/left_top_icon.dart
+++ b/app/lib/widgets/cards/productCard/shared/left_top_icon.dart
@@ -1,13 +1,13 @@
-import 'package:flex_ui/tokens/colors.dart';
 import 'package:flex_ui/tokens/sizes.dart';
+import 'package:flex_ui/utils/extensions.dart';
 import 'package:flutter/material.dart';
 
 class LeftTopIcon extends StatelessWidget {
   const LeftTopIcon({
     super.key,
     required this.label,
-    this.iconBackgroundColor = FlexColors.secondary,
-    this.textColor = Colors.white,
+    this.iconBackgroundColor,
+    this.textColor,
   });
 
   final String label;
@@ -20,8 +20,10 @@ class LeftTopIcon extends StatelessWidget {
       borderRadius: BorderRadius.circular(FlexSizes.circleRadius),
       child: Container(
         padding: const EdgeInsets.symmetric(
-            horizontal: FlexSizes.md, vertical: FlexSizes.xxs),
-        color: iconBackgroundColor,
+          horizontal: FlexSizes.md,
+          vertical: FlexSizes.xxs,
+        ),
+        color: iconBackgroundColor ?? context.colors.info,
         child: Text(
           label,
           style: Theme.of(context)

--- a/app/lib/widgets/cards/productCard/shared/product_info.dart
+++ b/app/lib/widgets/cards/productCard/shared/product_info.dart
@@ -1,5 +1,4 @@
 import 'package:flex_ui/flex_ui.dart';
-import 'package:flex_ui/utils/extensions.dart';
 import 'package:flex_ui/widgets/cards/productCard/shared/product_notation.dart';
 import 'package:flutter/material.dart';
 

--- a/app/lib/widgets/cards/productCard/shared/product_infos.dart
+++ b/app/lib/widgets/cards/productCard/shared/product_infos.dart
@@ -1,4 +1,5 @@
 import 'package:flex_ui/flex_ui.dart';
+import 'package:flex_ui/utils/extensions.dart';
 import 'package:flex_ui/widgets/cards/productCard/shared/product_notation.dart';
 import 'package:flutter/material.dart';
 
@@ -63,7 +64,9 @@ class ProductInfo extends StatelessWidget {
           if (isLandscape)
             Padding(
               padding: const EdgeInsets.only(
-                  top: FlexSizes.xxs, bottom: FlexSizes.sm),
+                top: FlexSizes.xxs,
+                bottom: FlexSizes.sm,
+              ),
               child: FlexProductRating(
                 rating: notation ?? 0,
               ),
@@ -80,7 +83,7 @@ class ProductInfo extends StatelessWidget {
                   TextSpan(
                     text: ' $currency$price',
                     style: infoContext.textTheme.headlineSmall
-                        ?.copyWith(color: FlexColors.success),
+                        ?.copyWith(color: context.colors.success),
                   ),
                 ],
               ),

--- a/app/lib/widgets/cards/productCard/shared/product_notation.dart
+++ b/app/lib/widgets/cards/productCard/shared/product_notation.dart
@@ -1,4 +1,4 @@
-import 'package:flex_ui/flex_ui.dart';
+import 'package:flex_ui/utils/extensions.dart';
 import 'package:flutter/material.dart';
 
 class FlexProductRating extends StatelessWidget {
@@ -19,16 +19,16 @@ class FlexProductRating extends StatelessWidget {
         children: List.generate(
           numberOfStars,
           (index) => (index < rating)
-              ? const Flexible(
+              ?  Flexible(
                   child: Icon(
                     Icons.star_rounded,
-                    color: FlexColors.warning,
+                    color: context.colors.warning,
                   ),
                 )
-              : const Flexible(
+              :  Flexible(
                   child: Icon(
                     Icons.star_border_rounded,
-                    color: FlexColors.disabled,
+                    color: context.colors.disabled,
                   ),
                 ),
         ),

--- a/app/lib/widgets/carousel/carousel.dart
+++ b/app/lib/widgets/carousel/carousel.dart
@@ -1,5 +1,6 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flex_ui/flex_ui.dart';
+import 'package:flex_ui/utils/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:widgetbook/widgetbook.dart';
@@ -78,7 +79,7 @@ class _FlexCarouselState extends State<FlexCarousel> {
             count: widget.items.length,
             effect: WormEffect(
               radius: 8.0,
-              activeDotColor: Theme.of(context).primaryColor,
+              activeDotColor: context.colors.primary,
             ),
           ),
         ],

--- a/app/lib/widgets/carousel/carousel.dart
+++ b/app/lib/widgets/carousel/carousel.dart
@@ -1,6 +1,5 @@
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:flex_ui/flex_ui.dart';
-import 'package:flex_ui/utils/extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:widgetbook/widgetbook.dart';

--- a/app/lib/widgets/image/image.dart
+++ b/app/lib/widgets/image/image.dart
@@ -99,7 +99,8 @@ class FlexImage extends StatelessWidget {
     );
 
     return ClipRRect(
-        borderRadius: borderRadius ?? BorderRadius.zero,
-        child: Semantics(label: semantics, child: content));
+      borderRadius: borderRadius ?? BorderRadius.zero,
+      child: Semantics(label: semantics, child: content),
+    );
   }
 }

--- a/app/lib/widgets/image/image_error.dart
+++ b/app/lib/widgets/image/image_error.dart
@@ -1,3 +1,4 @@
+import 'package:flex_ui/utils/extensions.dart';
 import 'package:flutter/material.dart';
 
 class ImageError extends StatelessWidget {
@@ -8,7 +9,7 @@ class ImageError extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget widget = Container(
-      color: Colors.grey[100]!,
+      color: context.colors.disabled,
       alignment: Alignment.center,
       child: const Icon(Icons.error),
     );


### PR DESCRIPTION
Create and manage custom color scheme (light & dark) 

Based on Flutter's recommendations & this article : https://medium.com/@alexandersnotes/flutter-custom-theme-with-themeextension-792034106abc 

- All colors in One place without override / copyWith anything in the UI
- You can add your own var colors instead of override only Materials colors
- Don’t depend on Material spec anymore

Maybe some Colors to be add / change, we need to figure it out how to handle Colors variants (in the ImageLoader for exemple), might be Color.swatch() 