### PR TITLE
13 featflex UI create flexprice widget

### DIFF
--- a/app/lib/main.directories.g.dart
+++ b/app/lib/main.directories.g.dart
@@ -16,6 +16,7 @@ import 'package:flex_ui/widgets/cards/productCard/product_card.dart' as _i6;
 import 'package:flex_ui/widgets/carousel/carousel.dart' as _i5;
 import 'package:flex_ui/widgets/quantity_selector/quantity_selector.dart'
     as _i7;
+import 'package:flex_ui/widgets/cards/productCard/shared/price.dart' as _i8;
 import 'package:widgetbook/widgetbook.dart' as _i1;
 
 final directories = <_i1.WidgetbookNode>[
@@ -73,6 +74,23 @@ final directories = <_i1.WidgetbookNode>[
           name: 'Central banner',
           builder: _i5.centralBannerCarousel,
         ),
+      ),
+      _i1.WidgetbookComponent(
+        name: 'Price',
+        useCases: [
+          _i1.WidgetbookUseCase(
+            name: 'Default w/ Formatter Callback',
+            builder: _i8.flexPrice,
+          ),
+          _i1.WidgetbookUseCase(
+            name: 'Sale',
+            builder: _i8.flexPriceSale,
+          ),
+          _i1.WidgetbookUseCase(
+            name: 'Style Override (No formatter)',
+            builder: _i8.priceStyleOverride,
+          ),
+        ],
       ),
       _i1.WidgetbookLeafComponent(
         name: 'FlexProductCard',

--- a/app/lib/main.directories.g.dart
+++ b/app/lib/main.directories.g.dart
@@ -76,7 +76,7 @@ final directories = <_i1.WidgetbookNode>[
         ),
       ),
       _i1.WidgetbookComponent(
-        name: 'Price',
+        name: 'FlexPrice',
         useCases: [
           _i1.WidgetbookUseCase(
             name: 'Default w/ Formatter Callback',

--- a/app/lib/widgets/cards/productCard/shared/price.dart
+++ b/app/lib/widgets/cards/productCard/shared/price.dart
@@ -4,35 +4,60 @@ import 'package:widgetbook/widgetbook.dart';
 import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:intl/intl.dart';
 
-enum Variant {
+/// A flexible price display widget that handles various e-commerce pricing scenarios.
+///
+/// This widget can display prices in different formats and styles, supporting:
+/// - Custom price formatting
+/// - Multiple display variants (standard, savings)
+/// - Theme customization
+/// - Accessibility features
+///
+/// Example usage:
+/// ```dart
+/// FlexPrice(
+///   price: 99.99,
+///   priceVariant: PriceVariant.standard,
+///   priceFormatter: (price) => NumberFormat.currency(locale: 'en_US').format(price),
+///)
+
+enum PriceVariant {
   standard,
-  savings, // Defaults to text decoration linethrough and color 'disabled'
+
+  /// Default Styling:
+  /// TextTheme.headerSmall
+
+  strikethrough,
+
+  /// Default Styling:
+  /// Color: Theme Disabled Color,
+  /// Text Decoration: Linethrough
 }
 
-class Price extends StatelessWidget {
-  const Price({
+class FlexPrice extends StatelessWidget {
+  const FlexPrice({
     super.key,
     required this.price,
-    this.formatterCallback,
-    this.variant = Variant.standard,
+    this.priceFormatter,
+    this.priceVariant = PriceVariant.standard,
     this.textStyle,
   });
+
   final double price;
-  final String Function(double)? formatterCallback;
-  final Variant? variant;
+  final String Function(double)? priceFormatter;
+  final PriceVariant priceVariant;
   final TextStyle? textStyle;
+
   @override
   Widget build(BuildContext context) {
     final defaultTheme = Theme.of(context);
 // @TODO before merge - potentially add theme fallback?
 
-    final formattedPrice = formatterCallback != null
-        ? formatterCallback!(price)
-        : price.toString();
+    final formattedPrice =
+        priceFormatter != null ? priceFormatter!(price) : price.toString();
 
-    final Map<Variant, TextStyle> variantTextStyle = {
-      Variant.standard: const TextStyle(),
-      Variant.savings: TextStyle(
+    final Map<PriceVariant, TextStyle> variantTextStyle = {
+      PriceVariant.standard: const TextStyle(),
+      PriceVariant.strikethrough: TextStyle(
         color: defaultTheme.disabledColor,
         decoration: TextDecoration.lineThrough,
       ),
@@ -41,7 +66,7 @@ class Price extends StatelessWidget {
     return Text(
       formattedPrice,
       style: defaultTheme.textTheme.headlineSmall
-          ?.merge(variantTextStyle[variant])
+          ?.merge(variantTextStyle[priceVariant])
           .merge(textStyle),
     );
   }
@@ -49,7 +74,7 @@ class Price extends StatelessWidget {
 
 @widgetbook.UseCase(
   name: 'Default',
-  type: Price,
+  type: FlexPrice,
   path: '[Components]',
 )
 Widget flexPrice(BuildContext context) {
@@ -62,9 +87,9 @@ Widget flexPrice(BuildContext context) {
   }
 
   return Center(
-    child: Price(
+    child: FlexPrice(
       price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
-      formatterCallback: (price) => exampleFormatter(
+      priceFormatter: (price) => exampleFormatter(
         price,
         context.knobs.list(
           label: 'Locale Examples',
@@ -73,7 +98,9 @@ Widget flexPrice(BuildContext context) {
           options: ['en-US', 'fr-CA', 'ja-JP'],
         ),
         decimalDigits: context.knobs.boolean(
-                label: 'Example 3 Decimal Place override', initialValue: false)
+          label: 'Example 3 Decimal Place override',
+          initialValue: false,
+        )
             ? 3
             : null,
       ),
@@ -82,8 +109,8 @@ Widget flexPrice(BuildContext context) {
 }
 
 @widgetbook.UseCase(
-  name: 'Sale',
-  type: Price,
+  name: 'Strikethrough',
+  type: FlexPrice,
   path: '[Components]',
 )
 Widget flexPriceSale(BuildContext context) {
@@ -96,30 +123,30 @@ Widget flexPriceSale(BuildContext context) {
   }
 
   return Center(
-    child: Price(
+    child: FlexPrice(
       price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
-      formatterCallback: (price) => exampleFormatter(
+      priceFormatter: (price) => exampleFormatter(
         price,
         context.knobs.list(
           label: 'Locale Examples',
           options: ['en-US', 'fr-CA', 'ja-JP'],
         ),
       ),
-      variant: Variant.savings,
+      priceVariant: PriceVariant.strikethrough,
     ),
   );
 }
 
 @widgetbook.UseCase(
   name: 'Style Override (No formatter)',
-  type: Price,
+  type: FlexPrice,
   path: '[Components]',
 )
 Widget priceStyleOverride(BuildContext context) {
   return Center(
-    child: Price(
+    child: FlexPrice(
       price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
-      variant: Variant.savings,
+      priceVariant: PriceVariant.strikethrough,
       textStyle:
           context.theme.textTheme.headlineLarge?.copyWith(color: Colors.green),
     ),

--- a/app/lib/widgets/cards/productCard/shared/price.dart
+++ b/app/lib/widgets/cards/productCard/shared/price.dart
@@ -23,7 +23,7 @@ class Price extends StatelessWidget {
   final TextStyle? textStyle;
   @override
   Widget build(BuildContext context) {
-    final defaultTheme = context.theme;
+    final defaultTheme = Theme.of(context);
 // @TODO before merge - potentially add theme fallback?
 
     final formattedPrice = formatterCallback != null

--- a/app/lib/widgets/cards/productCard/shared/price.dart
+++ b/app/lib/widgets/cards/productCard/shared/price.dart
@@ -18,19 +18,23 @@ import 'package:intl/intl.dart';
 ///   price: 99.99,
 ///   priceVariant: PriceVariant.standard,
 ///   priceFormatter: (price) => NumberFormat.currency(locale: 'en_US').format(price),
-///)
+///   priceLabel: "Sale Price {price}" // {price} token position indicates where the post formatter price should be placed in label
+/// )
+///
 
 enum PriceVariant {
   standard,
 
   /// Default Styling:
   /// TextTheme.headerSmall
+  /// priceLabel: 'Price $formattedPrice'
 
   strikethrough,
 
   /// Default Styling:
   /// Color: Theme Disabled Color,
   /// Text Decoration: Linethrough
+  /// Text Semantic Label: 'Strikethrough Price $formattedPrice'
 }
 
 class FlexPrice extends StatelessWidget {
@@ -40,17 +44,18 @@ class FlexPrice extends StatelessWidget {
     this.priceFormatter,
     this.priceVariant = PriceVariant.standard,
     this.textStyle,
+    this.priceLabel,
   });
 
   final double price;
   final String Function(double)? priceFormatter;
   final PriceVariant priceVariant;
   final TextStyle? textStyle;
+  final String? priceLabel;
 
   @override
   Widget build(BuildContext context) {
     final defaultTheme = Theme.of(context);
-// @TODO before merge - potentially add theme fallback?
 
     final formattedPrice =
         priceFormatter != null ? priceFormatter!(price) : price.toString();
@@ -63,11 +68,22 @@ class FlexPrice extends StatelessWidget {
       ),
     };
 
+    final Map<PriceVariant, String> defaultLabel = {
+      PriceVariant.standard: formattedPrice,
+      PriceVariant.strikethrough: 'Strikethrough Price $formattedPrice',
+    };
+
+    /// Allows for user determined formattedPrice positioning in label text, '{price}' string token is replaced with formatted price when present
+    final String resolvedPriceLabel = priceLabel?.contains('{price}') == true
+        ? priceLabel!.replaceAll('{price}', formattedPrice)
+        : (priceLabel ?? defaultLabel[priceVariant]!);
+
     return Text(
       formattedPrice,
       style: defaultTheme.textTheme.headlineSmall
           ?.merge(variantTextStyle[priceVariant])
           .merge(textStyle),
+      semanticsLabel: resolvedPriceLabel,
     );
   }
 }
@@ -133,6 +149,7 @@ Widget flexPriceSale(BuildContext context) {
         ),
       ),
       priceVariant: PriceVariant.strikethrough,
+      priceLabel: '{price} Before Discount',
     ),
   );
 }
@@ -149,6 +166,7 @@ Widget priceStyleOverride(BuildContext context) {
       priceVariant: PriceVariant.strikethrough,
       textStyle:
           context.theme.textTheme.headlineLarge?.copyWith(color: Colors.green),
+      priceLabel: 'Example {price} Label Positioning',
     ),
   );
 }

--- a/app/lib/widgets/cards/productCard/shared/price.dart
+++ b/app/lib/widgets/cards/productCard/shared/price.dart
@@ -1,0 +1,130 @@
+import 'package:flex_ui/utils/extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:intl/intl.dart';
+
+enum Variant {
+  standard,
+  savings, // Defaults to text decoration linethrough and color 'disabled'
+}
+
+class Price extends StatelessWidget {
+  const Price({
+    super.key,
+    required this.price,
+    this.oldPrice,
+    this.formatterCallback,
+    this.variant = Variant.standard,
+    this.textStyle,
+  });
+  final double price;
+  final double? oldPrice;
+  final Function? formatterCallback;
+  final Variant? variant;
+  final TextStyle? textStyle;
+  @override
+  Widget build(BuildContext context) {
+    final defaultTheme = context.theme;
+// @TODO before merge - potentially add theme fallback?
+
+    final formattedPrice = formatterCallback != null
+        ? formatterCallback!(price)
+        : price.toString();
+
+    final Map<Variant, TextStyle> variantTextStyle = {
+      Variant.standard: const TextStyle(),
+      Variant.savings: TextStyle(
+        color: defaultTheme.disabledColor,
+        decoration: TextDecoration.lineThrough,
+      ),
+    };
+
+    return Text(
+      formattedPrice,
+      style: defaultTheme.textTheme.headlineSmall
+          ?.merge(variantTextStyle[variant])
+          .merge(textStyle),
+    );
+  }
+}
+
+@widgetbook.UseCase(
+  name: 'Default',
+  type: Price,
+  path: '[Components]',
+)
+Widget flexPrice(BuildContext context) {
+  exampleFormatter(double price, String locale, {int? decimalDigits}) {
+    final formatter = NumberFormat.simpleCurrency(
+      locale: locale,
+      decimalDigits: decimalDigits,
+    );
+    return formatter.format(price);
+  }
+
+  return Center(
+    child: Price(
+      price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
+      oldPrice: 200.52,
+      formatterCallback: (price) => exampleFormatter(
+        price,
+        context.knobs.list(
+          label: 'Locale Examples',
+          description:
+              'Example Formats: \n   en-US: Standard USD Format \n   fr-CA:\$ right of value \n   ja-JP: No decimals, rounded to nearst whole',
+          options: ['en-US', 'fr-CA', 'ja-JP'],
+        ),
+        decimalDigits: context.knobs.boolean(
+                label: 'Example 3 Decimal Place override', initialValue: false)
+            ? 3
+            : null,
+      ),
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Sale',
+  type: Price,
+  path: '[Components]',
+)
+Widget flexPriceSale(BuildContext context) {
+  exampleFormatter(double price, String locale, {int? decimalDigits}) {
+    final formatter = NumberFormat.simpleCurrency(
+      locale: locale,
+      decimalDigits: decimalDigits,
+    );
+    return formatter.format(price);
+  }
+
+  return Center(
+    child: Price(
+      price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
+      formatterCallback: (price) => exampleFormatter(
+        price,
+        context.knobs.list(
+          label: 'Locale Examples',
+          options: ['en-US', 'fr-CA', 'ja-JP'],
+        ),
+      ),
+      variant: Variant.savings,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Style Override (No formatter)',
+  type: Price,
+  path: '[Components]',
+)
+Widget priceStyleOverride(BuildContext context) {
+  return Center(
+    child: Price(
+      price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
+      variant: Variant.savings,
+      textStyle:
+          context.theme.textTheme.headlineLarge?.copyWith(color: Colors.green),
+    ),
+  );
+}

--- a/app/lib/widgets/cards/productCard/shared/price.dart
+++ b/app/lib/widgets/cards/productCard/shared/price.dart
@@ -18,7 +18,7 @@ class Price extends StatelessWidget {
     this.textStyle,
   });
   final double price;
-  final Function? formatterCallback;
+  final String Function(double)? formatterCallback;
   final Variant? variant;
   final TextStyle? textStyle;
   @override

--- a/app/lib/widgets/cards/productCard/shared/price.dart
+++ b/app/lib/widgets/cards/productCard/shared/price.dart
@@ -13,13 +13,11 @@ class Price extends StatelessWidget {
   const Price({
     super.key,
     required this.price,
-    this.oldPrice,
     this.formatterCallback,
     this.variant = Variant.standard,
     this.textStyle,
   });
   final double price;
-  final double? oldPrice;
   final Function? formatterCallback;
   final Variant? variant;
   final TextStyle? textStyle;
@@ -66,7 +64,6 @@ Widget flexPrice(BuildContext context) {
   return Center(
     child: Price(
       price: context.knobs.double.input(label: 'Price', initialValue: 150.99),
-      oldPrice: 200.52,
       formatterCallback: (price) => exampleFormatter(
         price,
         context.knobs.list(

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -344,6 +344,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -345,7 +345,7 @@ packages:
     source: hosted
     version: "2.1.0"
   intl:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -24,6 +24,7 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   widgetbook_generator: ^3.9.0
   build_runner: ^2.4.12
+  intl: ^0.19.0
 
 flutter:
   uses-material-design: true

--- a/playground/pubspec.lock
+++ b/playground/pubspec.lock
@@ -258,10 +258,10 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   fixnum:
     dependency: transitive
     description:
@@ -588,6 +588,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: c8a055ee5ce3fd98d6fc872478b03823ffdb448699c6ebdbbc71d59b596fd48c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.2"
   pub_semver:
     dependency: transitive
     description:


### PR DESCRIPTION
## Price widget - Preliminary PR
Default w/ Intl Formatter callback | Savings Variant |
------|------
En-US ![image](https://github.com/user-attachments/assets/e37c74ce-36c9-4e11-ad78-977ec28e22df) JA-JP ![image](https://github.com/user-attachments/assets/5e6c11e3-d189-43ff-b795-badf8d996314)| Savings w/ Formatter ![image](https://github.com/user-attachments/assets/22952333-f925-4db1-a24e-4d687dd426c8) No Formatter, w/ TextStyle Override ![image](https://github.com/user-attachments/assets/885ec53c-bc78-40cb-8ca1-29f65451a057) 

Small core Text widget to enable price formatting with users library of choice.

Follows rough approach seen here 
https://developers.vtex.com/docs/guides/faststore/atoms-price

The widget its self does not handle the core currency formatting price logic, which removes any widget internationalization library dependency for the user. Instead pass a callback function to formatterCallback to handle formatting logic.

Input params
- formatterCallback: callback function for price string formatting
- price (Double)
- Variant - Currently only default @ savings
- TextStyle - override currently applied stiles

Variants: By default using textTheme: Headline Small
- Default
- Savings (Text strikethrough)

### Note
PR adds Dart intl library for widgetbook example - Currently dev dependency, do we want this added (does it need to be core dep)