### PR TITLE
Feat UI: FlexPriceDiscount Widget Added -Manages Product Card Price/Discount Price Display Logic

### DIFF
--- a/app/lib/main.directories.g.dart
+++ b/app/lib/main.directories.g.dart
@@ -18,6 +18,8 @@ import 'package:flex_ui/widgets/carousel/carousel.dart' as _i5;
 import 'package:flex_ui/widgets/quantity_selector/quantity_selector.dart'
     as _i8;
 import 'package:widgetbook/widgetbook.dart' as _i1;
+import 'package:flex_ui/widgets/cards/productCard/shared/price_discount.dart'
+    as _i9;
 
 final directories = <_i1.WidgetbookNode>[
   _i1.WidgetbookCategory(
@@ -91,6 +93,13 @@ final directories = <_i1.WidgetbookNode>[
             builder: _i6.priceStyleOverride,
           ),
         ],
+      ),
+      _i1.WidgetbookLeafComponent(
+        name: 'FlexPriceDiscount',
+        useCase: _i1.WidgetbookUseCase(
+          name: 'Default',
+          builder: _i9.defaultPriceDiscount,
+        ),
       ),
       _i1.WidgetbookComponent(
         name: 'FlexProductCard',

--- a/app/lib/widgets/cards/productCard/content_product_card.dart
+++ b/app/lib/widgets/cards/productCard/content_product_card.dart
@@ -10,8 +10,13 @@ class FlexContentProductCard extends StatelessWidget {
     this.productReference,
     required this.imageUrl,
     required this.price,
+    this.priceLabel,
+    this.priceStyle,
     this.oldPrice,
-    required this.currency,
+    this.oldPriceLabel,
+    this.oldPriceStyle,
+    this.discountPriceStyle,
+    this.priceFormatter,
     this.notation,
     required this.isAvailable,
     required this.isLandscape,
@@ -22,10 +27,15 @@ class FlexContentProductCard extends StatelessWidget {
   final String imageUrl;
   final double price;
   final double? oldPrice;
-  final String currency;
   final int? notation;
   final bool isAvailable;
   final bool isLandscape;
+  final String Function(double)? priceFormatter;
+  final String? priceLabel;
+  final String? oldPriceLabel;
+  final TextStyle? priceStyle;
+  final TextStyle? oldPriceStyle;
+  final TextStyle? discountPriceStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -34,8 +44,13 @@ class FlexContentProductCard extends StatelessWidget {
         productName: productName,
         productReference: productReference,
         price: price,
+        priceLabel: priceLabel,
+        priceStyle: priceStyle,
         oldPrice: oldPrice,
-        currency: currency,
+        oldPriceLabel: oldPriceLabel,
+        oldPriceStyle: oldPriceStyle,
+        discountPriceStyle: discountPriceStyle,
+        priceFormatter: priceFormatter,
         notation: notation,
         isLandscape: isLandscape,
       ),

--- a/app/lib/widgets/cards/productCard/product_card.dart
+++ b/app/lib/widgets/cards/productCard/product_card.dart
@@ -14,8 +14,13 @@ class FlexProductCard extends StatelessWidget {
     this.productReference,
     required this.imageUrl,
     required this.price,
+    this.priceFormatter,
+    this.priceLabel,
+    this.priceStyle,
     this.oldPrice,
-    required this.currency,
+    this.oldPriceLabel,
+    this.oldPriceStyle,
+    this.discountPriceStyle,
     this.notation,
     this.displayLeftIcon = false,
     this.leftIconLabel,
@@ -44,8 +49,13 @@ class FlexProductCard extends StatelessWidget {
   final String? productReference;
   final String imageUrl;
   final double price;
+  final String Function(double)? priceFormatter;
   final double? oldPrice;
-  final String currency;
+  final String? priceLabel;
+  final String? oldPriceLabel;
+  final TextStyle? priceStyle;
+  final TextStyle? oldPriceStyle;
+  final TextStyle? discountPriceStyle;
   final int? notation;
   final bool displayLeftIcon;
   final String? leftIconLabel;
@@ -77,8 +87,13 @@ class FlexProductCard extends StatelessWidget {
               productReference: productReference,
               imageUrl: imageUrl,
               price: price,
+              priceLabel: priceLabel,
+              priceStyle: priceStyle,
               oldPrice: oldPrice,
-              currency: currency,
+              oldPriceLabel: oldPriceLabel,
+              oldPriceStyle: oldPriceStyle,
+              discountPriceStyle: discountPriceStyle,
+              priceFormatter: priceFormatter,
               notation: notation,
               isAvailable: isAvailable,
               isLandscape: isLandscape,
@@ -132,14 +147,14 @@ Widget standardFlexProductCard(BuildContext context) {
       child: FlexProductCard(
         productName: 'Temple Fork TFO NXT Series Fly Rod',
         productReference: 'TFO NXT 905 5/6',
-        price: 159,
+        price: context.knobs.double.input(label: 'price', initialValue: 150),
         oldPrice:
             context.knobs.double.input(label: 'oldPrice', initialValue: 0),
+        priceFormatter: (price) => '\$$price',
         imageUrl: 'https://picsum.photos/200',
         notation: 4,
         isLandscape:
             context.knobs.boolean(label: 'isLandscape', initialValue: false),
-        currency: "\$",
         displayLeftIcon: context.knobs
             .boolean(label: 'displayLeftIcon', initialValue: false),
         leftIconLabel: 'New',
@@ -191,10 +206,10 @@ Widget gridFlexProductCard(BuildContext context) {
       productReference: 'TFO NXT 905 5/6',
       price: 159,
       oldPrice: context.knobs.double.input(label: 'oldPrice', initialValue: 0),
+      priceFormatter: (price) => '\$$price',
       imageUrl: 'https://picsum.photos/200',
       notation: 4,
       isLandscape: isLandscape,
-      currency: "\$",
       displayLeftIcon:
           context.knobs.boolean(label: 'displayLeftIcon', initialValue: false),
       leftIconLabel: 'New',

--- a/app/lib/widgets/cards/productCard/shared/price_discount.dart
+++ b/app/lib/widgets/cards/productCard/shared/price_discount.dart
@@ -1,0 +1,116 @@
+import 'package:flex_ui/widgets/cards/productCard/shared/price.dart';
+import 'package:flutter/material.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+import 'package:flex_ui/flex_ui.dart';
+import 'package:intl/intl.dart';
+
+class FlexPriceDiscount extends StatelessWidget {
+  const FlexPriceDiscount({
+    super.key,
+    required this.price,
+    this.oldPrice,
+    this.priceFormatter,
+    this.enableLineWrap = false,
+    this.priceLabel,
+    this.priceStyle,
+    this.discountPriceStyle,
+    this.oldPriceLabel,
+    this.oldPriceStyle,
+  });
+  final double price;
+  final double? oldPrice;
+  final String Function(double)? priceFormatter;
+  final bool enableLineWrap;
+  final String? priceLabel;
+  final String? oldPriceLabel;
+  final TextStyle? priceStyle;
+  final TextStyle? oldPriceStyle;
+  final TextStyle? discountPriceStyle;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool displayDiscount =
+        oldPrice != null && oldPrice! > 0 ? true : false;
+
+    final List<Widget> priceWidgets = [
+      if (displayDiscount)
+        FlexPrice(
+          price: oldPrice!,
+          priceFormatter: priceFormatter,
+          priceVariant: PriceVariant.strikethrough,
+          textStyle: const TextStyle(
+            overflow: TextOverflow.ellipsis,
+          ).merge(oldPriceStyle),
+          priceLabel: oldPriceLabel,
+        ),
+
+      // If isLandscape wrap spacing will handle gap between prices, otherwise sized box between row items
+      if (!enableLineWrap) const SizedBox(width: 4),
+
+      FlexPrice(
+        price: price,
+        priceFormatter: priceFormatter,
+        textStyle: TextStyle(
+          color: context.colors.success,
+          overflow: TextOverflow.ellipsis,
+        ).merge(discountPriceStyle),
+        priceLabel: priceLabel,
+      ),
+    ];
+
+    final discountPriceLayout = enableLineWrap
+        ? Wrap(spacing: 4, children: priceWidgets)
+        : IntrinsicWidth(
+            child: Row(
+              children: priceWidgets.map((widget) {
+                if (widget is SizedBox) {
+                  return widget;
+                }
+                return Flexible(child: widget);
+              }).toList(),
+            ),
+          );
+
+    return displayDiscount
+        ? discountPriceLayout
+        : FlexPrice(
+            price: price,
+            priceFormatter: priceFormatter,
+            textStyle: const TextStyle(
+              overflow: TextOverflow.ellipsis,
+            ).merge(priceStyle),
+            priceLabel: priceLabel,
+          );
+  }
+}
+
+@widgetbook.UseCase(
+  name: 'Default',
+  type: FlexPriceDiscount,
+  path: '[Components]',
+)
+Widget defaultPriceDiscount(BuildContext context) {
+  exampleFormatter(
+    double price,
+  ) {
+    final formatter = NumberFormat.simpleCurrency(
+      locale: context.knobs.list(
+        label: 'Locale Examples',
+        options: ['en-US', 'fr-CA', 'ja-JP'],
+      ),
+      decimalDigits: 2,
+    );
+    return formatter.format(price);
+  }
+
+  return Center(
+    child: FlexPriceDiscount(
+      price: 200.00,
+      oldPrice:
+          context.knobs.double.input(label: 'oldPrice', initialValue: 300),
+      priceFormatter: exampleFormatter,
+      oldPriceLabel: 'originally {price}',
+    ),
+  );
+}

--- a/app/lib/widgets/cards/productCard/shared/price_discount.dart
+++ b/app/lib/widgets/cards/productCard/shared/price_discount.dart
@@ -91,6 +91,7 @@ class FlexPriceDiscount extends StatelessWidget {
   path: '[Components]',
 )
 Widget defaultPriceDiscount(BuildContext context) {
+  final theme = Theme.of(context);
   exampleFormatter(
     double price,
   ) {
@@ -111,6 +112,13 @@ Widget defaultPriceDiscount(BuildContext context) {
           context.knobs.double.input(label: 'oldPrice', initialValue: 300),
       priceFormatter: exampleFormatter,
       oldPriceLabel: 'originally {price}',
+      discountPriceStyle: context.knobs.boolean(
+        label: 'Example Discount Price Style Override',
+        initialValue: false,
+      )
+          ? theme.textTheme.headlineMedium!
+              .merge(const TextStyle(color: Colors.blue))
+          : null,
     ),
   );
 }

--- a/app/lib/widgets/cards/productCard/shared/price_discount.dart
+++ b/app/lib/widgets/cards/productCard/shared/price_discount.dart
@@ -64,10 +64,8 @@ class FlexPriceDiscount extends StatelessWidget {
           ).merge(oldPriceStyle),
           priceLabel: oldPriceLabel,
         ),
-
-      // If isLandscape wrap spacing will handle gap between prices, otherwise sized box between row items
+      // If single line, spacer between prices elements, otherwise Wrap spacer provided
       if (!enableLineWrap) const SizedBox(width: 4),
-
       FlexPrice(
         price: price,
         priceFormatter: priceFormatter,
@@ -79,10 +77,12 @@ class FlexPriceDiscount extends StatelessWidget {
       ),
     ];
 
-    final discountPriceLayout = enableLineWrap
+// Row or Wrap Price Widgets to dependent on enableLineWrap toggle
+    final Widget discountPriceLayout = enableLineWrap
         ? Wrap(spacing: 4, children: priceWidgets)
         : IntrinsicWidth(
             child: Row(
+              // Row Price Widgets to be wrapped in flexible as overflow Guardrail for Product Card
               children: priceWidgets.map((widget) {
                 if (widget is SizedBox) {
                   return widget;

--- a/app/lib/widgets/cards/productCard/shared/price_discount.dart
+++ b/app/lib/widgets/cards/productCard/shared/price_discount.dart
@@ -5,6 +5,26 @@ import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
 import 'package:flex_ui/flex_ui.dart';
 import 'package:intl/intl.dart';
 
+/// This widget leverages the ``FlexPrice`` Widget for Price Formatting and display, but provides additional convenience for the conditional rendering of Sale Prices
+///
+/// Widget
+/// - custom price formatting
+/// - Theme customization for Price, Discount Price & Old Price values
+/// - Price & Old Price Semantic Label Optional Parameters
+/// - single line or line Wrap parameter for Price Value overflows
+/// - When no 'oldPrice' is present, fallback to standard ``FlexPrice``
+///
+/// Example usage:
+/// ```dart
+/// FlexPriceDiscount(
+///   price: 99.99,
+///   oldPrice: 200.00,
+///   discountPriceStyle: TextStyle(color: Colors.green), // Example optional style override
+///   priceFormatter: (price) => NumberFormat.currency(locale: 'en_US').format(price),
+///   priceLabel: "Sale Price {price}" // {price} token position indicates where the post formatter price should be placed in label
+/// )
+///
+
 class FlexPriceDiscount extends StatelessWidget {
   const FlexPriceDiscount({
     super.key,
@@ -107,7 +127,7 @@ Widget defaultPriceDiscount(BuildContext context) {
 
   return Center(
     child: FlexPriceDiscount(
-      price: 200.00,
+      price: context.knobs.double.input(label: 'Price', initialValue: 200),
       oldPrice:
           context.knobs.double.input(label: 'oldPrice', initialValue: 300),
       priceFormatter: exampleFormatter,
@@ -119,6 +139,10 @@ Widget defaultPriceDiscount(BuildContext context) {
           ? theme.textTheme.headlineMedium!
               .merge(const TextStyle(color: Colors.blue))
           : null,
+      enableLineWrap: context.knobs.boolean(
+        label: 'Enable Line Wrap when price values overflow',
+        initialValue: false,
+      ),
     ),
   );
 }

--- a/app/lib/widgets/cards/productCard/shared/product_info.dart
+++ b/app/lib/widgets/cards/productCard/shared/product_info.dart
@@ -1,4 +1,5 @@
 import 'package:flex_ui/flex_ui.dart';
+import 'package:flex_ui/widgets/cards/productCard/shared/price_discount.dart';
 import 'package:flex_ui/widgets/cards/productCard/shared/product_notation.dart';
 import 'package:flutter/material.dart';
 
@@ -10,7 +11,12 @@ class ProductInfo extends StatelessWidget {
     this.productReference,
     required this.price,
     this.oldPrice,
-    required this.currency,
+    this.priceLabel,
+    this.priceStyle,
+    this.oldPriceLabel,
+    this.oldPriceStyle,
+    this.discountPriceStyle,
+    this.priceFormatter,
     this.notation,
   });
 
@@ -18,14 +24,18 @@ class ProductInfo extends StatelessWidget {
   final String? productReference;
   final double price;
   final double? oldPrice;
-  final String currency;
   final int? notation;
   final bool isLandscape;
+  final String Function(double)? priceFormatter;
+  final String? priceLabel;
+  final String? oldPriceLabel;
+  final TextStyle? priceStyle;
+  final TextStyle? oldPriceStyle;
+  final TextStyle? discountPriceStyle;
 
   @override
   Widget build(BuildContext context) {
     final infoContext = Theme.of(context);
-
     return Padding(
       padding: const EdgeInsets.all(FlexSizes.md),
       child: Column(
@@ -70,29 +80,17 @@ class ProductInfo extends StatelessWidget {
                 rating: notation ?? 0,
               ),
             ),
-          if (oldPrice != null && oldPrice! > 0)
-            RichText(
-              maxLines: 1,
-              text: TextSpan(
-                text: '$currency$oldPrice',
-                style: infoContext.textTheme.headlineSmall?.copyWith(
-                  decoration: TextDecoration.lineThrough,
-                ),
-                children: [
-                  TextSpan(
-                    text: ' $currency$price',
-                    style: infoContext.textTheme.headlineSmall
-                        ?.copyWith(color: context.colors.success),
-                  ),
-                ],
-              ),
-            )
-          else
-            Text(
-              '$currency$price',
-              style: infoContext.textTheme.headlineSmall,
-              overflow: TextOverflow.fade,
-            ),
+          FlexPriceDiscount(
+            price: price,
+            oldPrice: oldPrice,
+            priceFormatter: priceFormatter,
+            priceStyle: priceStyle,
+            priceLabel: priceLabel,
+            oldPriceLabel: oldPriceLabel,
+            oldPriceStyle: oldPriceStyle,
+            discountPriceStyle: discountPriceStyle,
+            enableLineWrap: isLandscape,
+          ),
         ],
       ),
     );


### PR DESCRIPTION
# Adds FlexPriceDiscount Widget
- Utilized ``FlexPrice`` Widget to handle conditional rendering around Price/Sale Price displays
- FallBack to a standard ``FlexPrice`` display of ``Price`` value if no ``oldPrice`` value is present (ie. no sale/discount) 
- Adds price text overflow guard-rails to Product Card component 
- Allows for all the same override functionality as ``FlexPrice`` for TextStyle and SemanticLabel passthrough
- Provides Single Line/ Line-wrap toggle param for Price display for flexible use in different scenarios
- Allows for Future extensibility to displaying Discount %, and reordering of Price Elements

Updates ProductCard widget to utilize this widget, instead of the prior placeholder TextSpan  implementation

Old Price Provided | No Old Price 
------ | -----
![image](https://github.com/user-attachments/assets/d6b6f4ae-4370-472a-947b-0c8854462a3e)|![image](https://github.com/user-attachments/assets/3b291271-96ab-4a6e-a11e-5b01af5a5e8f)
![image](https://github.com/user-attachments/assets/8597194a-4f27-4318-9282-0e64396ce8fa) | ![image](https://github.com/user-attachments/assets/ac046ce6-eb57-46c4-8024-ae4f5e65844f)


| Product Card Price Text Overflow Guards |
| ----- |
![image](https://github.com/user-attachments/assets/9a098e23-84cd-4db1-854c-543176c55e96)
![image](https://github.com/user-attachments/assets/9e7cd88c-a84c-4bfc-8478-2a7474f4b309)
![image](https://github.com/user-attachments/assets/50c05292-9a1a-4410-a484-53ed88f026c7)

