### PR TITLE
Removes breaking null check error when theme for IconButton.style is not set

### DIFF
--- a/app/lib/widgets/quantity_selector/quantity_selector.dart
+++ b/app/lib/widgets/quantity_selector/quantity_selector.dart
@@ -34,22 +34,26 @@ class FlexQuantitySelector extends StatelessWidget {
     final canDecrement = quantity - increment >= minQuantity;
     final canIncrement = quantity + increment <= maxQuantity;
 
+    final theme = Theme.of(context);
+    // Fallback theme styling if IconButtonTheme.style is not set by library user
+    final themeStyle = Theme.of(context).iconButtonTheme.style ?? ButtonStyle();
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
         IconButton(
           padding: EdgeInsets.zero,
-          style: Theme.of(context).iconButtonTheme.style!.copyWith(
-                padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-                shape: const WidgetStatePropertyAll(
-                  RoundedRectangleBorder(
-                    borderRadius: BorderRadius.only(
-                      topLeft: Radius.circular(FlexSizes.borderRadiusSm),
-                      bottomLeft: Radius.circular(FlexSizes.borderRadiusSm),
-                    ),
-                  ),
+          style: themeStyle.copyWith(
+            padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+            shape: const WidgetStatePropertyAll(
+              RoundedRectangleBorder(
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(FlexSizes.borderRadiusSm),
+                  bottomLeft: Radius.circular(FlexSizes.borderRadiusSm),
                 ),
               ),
+            ),
+          ),
           icon: const Icon(
             Icons.remove,
           ),
@@ -71,11 +75,11 @@ class FlexQuantitySelector extends StatelessWidget {
           decoration: BoxDecoration(
             border: Border.symmetric(
               horizontal: BorderSide(
-                color: Theme.of(context)
-                    .iconButtonTheme
-                    .style!
-                    .backgroundColor!
-                    .resolve({if (disabled) WidgetState.disabled})!,
+                color: themeStyle.backgroundColor
+                        ?.resolve({if (disabled) WidgetState.disabled}) ??
+                    (disabled
+                        ? theme.colorScheme.surfaceContainer
+                        : theme.colorScheme.surfaceContainerHigh),
               ),
             ),
           ),
@@ -89,17 +93,17 @@ class FlexQuantitySelector extends StatelessWidget {
           icon: const Icon(
             Icons.add,
           ),
-          style: Theme.of(context).iconButtonTheme.style!.copyWith(
-                padding: const WidgetStatePropertyAll(EdgeInsets.zero),
-                shape: const WidgetStatePropertyAll(
-                  RoundedRectangleBorder(
-                    borderRadius: BorderRadius.only(
-                      topRight: Radius.circular(FlexSizes.borderRadiusSm),
-                      bottomRight: Radius.circular(FlexSizes.borderRadiusSm),
-                    ),
-                  ),
+          style: themeStyle.copyWith(
+            padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+            shape: const WidgetStatePropertyAll(
+              RoundedRectangleBorder(
+                borderRadius: BorderRadius.only(
+                  topRight: Radius.circular(FlexSizes.borderRadiusSm),
+                  bottomRight: Radius.circular(FlexSizes.borderRadiusSm),
                 ),
               ),
+            ),
+          ),
           onPressed: canIncrement && !disabled
               ? () {
                   final newQuantity = quantity + increment;

--- a/app/lib/widgets/quantity_selector/quantity_selector.dart
+++ b/app/lib/widgets/quantity_selector/quantity_selector.dart
@@ -36,7 +36,8 @@ class FlexQuantitySelector extends StatelessWidget {
 
     final theme = Theme.of(context);
     // Fallback theme styling if IconButtonTheme.style is not set by library user
-    final themeStyle = Theme.of(context).iconButtonTheme.style ?? ButtonStyle();
+    final themeStyle =
+        Theme.of(context).iconButtonTheme.style ?? const ButtonStyle();
 
     return Row(
       mainAxisSize: MainAxisSize.min,

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -345,7 +345,7 @@ packages:
     source: hosted
     version: "2.1.0"
   intl:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   file: ^7.0.1
   flutter:
     sdk: flutter
+  intl: ^0.19.0
   provider: ^6.1.2
   shimmer: ^3.0.0
   smooth_page_indicator: ^1.2.0+3
@@ -24,7 +25,6 @@ dev_dependencies:
   flutter_lints: ^4.0.0
   widgetbook_generator: ^3.9.0
   build_runner: ^2.4.12
-  intl: ^0.19.0
 
 flutter:
   uses-material-design: true

--- a/playground/pubspec.lock
+++ b/playground/pubspec.lock
@@ -372,6 +372,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:


### PR DESCRIPTION
### Problem state - Seen when no IconButton.style is set in users theme
<img width="396" alt="image" src="https://github.com/user-attachments/assets/d918a850-ac3a-4cae-802a-4af7f3e81d2b">

### Updated Widget
**Widgetbook**: IconButton.style set in theme (FlexTheme)
![image](https://github.com/user-attachments/assets/8dec00cd-e4bb-435b-827c-1996013052b3)

**New** state fallback state when No IconButton.style exisits (Flex_starter)
<img width="319" alt="image" src="https://github.com/user-attachments/assets/a36a88c0-54b6-42d9-a5ae-289532e744e7">