### PR TITLE
feat(widget): connectivity_indicator

### DIFF
--- a/app/lib/main.directories.g.dart
+++ b/app/lib/main.directories.g.dart
@@ -1,3 +1,4 @@
+// dart format width=80
 // coverage:ignore-file
 // ignore_for_file: type=lint
 // ignore_for_file: unused_import, prefer_relative_imports, directives_ordering
@@ -12,16 +13,18 @@
 import 'package:flex_ui/widgets/app_bar/app_bar.dart' as _i2;
 import 'package:flex_ui/widgets/banner/banner.dart' as _i4;
 import 'package:flex_ui/widgets/buttons/button.dart' as _i5;
-import 'package:flex_ui/widgets/cards/productCard/product_card.dart' as _i9;
+import 'package:flex_ui/widgets/cards/productCard/product_card.dart' as _i10;
 import 'package:flex_ui/widgets/cards/productCard/shared/badge.dart' as _i3;
-import 'package:flex_ui/widgets/cards/productCard/shared/price.dart' as _i7;
+import 'package:flex_ui/widgets/cards/productCard/shared/price.dart' as _i8;
 import 'package:flex_ui/widgets/cards/productCard/shared/price_discount.dart'
-    as _i8;
+    as _i9;
 import 'package:flex_ui/widgets/carousel/carousel.dart' as _i6;
-import 'package:flex_ui/widgets/gallery/gallery.dart' as _i12;
+import 'package:flex_ui/widgets/connectivity/connectivity_indicator.dart'
+    as _i7;
+import 'package:flex_ui/widgets/gallery/gallery.dart' as _i13;
 import 'package:flex_ui/widgets/quantity_selector/quantity_selector.dart'
-    as _i10;
-import 'package:flex_ui/widgets/search/search.dart' as _i11;
+    as _i11;
+import 'package:flex_ui/widgets/search/search.dart' as _i12;
 import 'package:widgetbook/widgetbook.dart' as _i1;
 
 final directories = <_i1.WidgetbookNode>[
@@ -94,19 +97,40 @@ final directories = <_i1.WidgetbookNode>[
         ),
       ),
       _i1.WidgetbookComponent(
+        name: 'FlexConnectivityIndicator',
+        useCases: [
+          _i1.WidgetbookUseCase(
+            name: 'Connected',
+            builder: _i7.connectedIndicator,
+          ),
+          _i1.WidgetbookUseCase(
+            name: 'Custom Colors',
+            builder: _i7.customColorIndicator,
+          ),
+          _i1.WidgetbookUseCase(
+            name: 'Disconnected',
+            builder: _i7.disconnectedIndicator,
+          ),
+          _i1.WidgetbookUseCase(
+            name: 'Unknown',
+            builder: _i7.unknownIndicator,
+          ),
+        ],
+      ),
+      _i1.WidgetbookComponent(
         name: 'FlexPrice',
         useCases: [
           _i1.WidgetbookUseCase(
             name: 'Default',
-            builder: _i7.flexPrice,
+            builder: _i8.flexPrice,
           ),
           _i1.WidgetbookUseCase(
             name: 'Strikethrough',
-            builder: _i7.flexPriceSale,
+            builder: _i8.flexPriceSale,
           ),
           _i1.WidgetbookUseCase(
             name: 'Style Override (No formatter)',
-            builder: _i7.priceStyleOverride,
+            builder: _i8.priceStyleOverride,
           ),
         ],
       ),
@@ -115,11 +139,11 @@ final directories = <_i1.WidgetbookNode>[
         useCases: [
           _i1.WidgetbookUseCase(
             name: 'Default',
-            builder: _i8.defaultPriceDiscount,
+            builder: _i9.defaultPriceDiscount,
           ),
           _i1.WidgetbookUseCase(
             name: 'Default - No Sale Price',
-            builder: _i8.fallbackPriceDiscount,
+            builder: _i9.fallbackPriceDiscount,
           ),
         ],
       ),
@@ -128,11 +152,11 @@ final directories = <_i1.WidgetbookNode>[
         useCases: [
           _i1.WidgetbookUseCase(
             name: 'Grid',
-            builder: _i9.gridFlexProductCard,
+            builder: _i10.gridFlexProductCard,
           ),
           _i1.WidgetbookUseCase(
             name: 'Standard',
-            builder: _i9.standardFlexProductCard,
+            builder: _i10.standardFlexProductCard,
           ),
         ],
       ),
@@ -140,14 +164,14 @@ final directories = <_i1.WidgetbookNode>[
         name: 'FlexQuantitySelector',
         useCase: _i1.WidgetbookUseCase(
           name: 'Default',
-          builder: _i10.defaultQuantitySelector,
+          builder: _i11.defaultQuantitySelector,
         ),
       ),
       _i1.WidgetbookLeafComponent(
         name: 'FlexSearch',
         useCase: _i1.WidgetbookUseCase(
           name: 'Default',
-          builder: _i11.flexSearchStandard,
+          builder: _i12.flexSearchStandard,
         ),
       ),
     ],
@@ -162,7 +186,7 @@ final directories = <_i1.WidgetbookNode>[
             name: 'FlexGallery',
             useCase: _i1.WidgetbookUseCase(
               name: 'Default',
-              builder: _i12.defaultCarousel,
+              builder: _i13.defaultCarousel,
             ),
           )
         ],

--- a/app/lib/widgets/connectivity/connectivity_indicator.dart
+++ b/app/lib/widgets/connectivity/connectivity_indicator.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/material.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+/// A simple connectivity indicator that shows network status as an icon
+///
+/// Displays different Wi-Fi icons based on connection status:
+/// - Connected (isConnected = true): Wi-Fi icon
+/// - Disconnected (isConnected = false): Wi-Fi icon with slash
+/// - Unknown (isConnected = null): Wi-Fi icon with question mark
+class FlexConnectivityIndicator extends StatelessWidget {
+  const FlexConnectivityIndicator({
+    super.key,
+    this.isConnected,
+    this.iconSize = 24.0,
+    this.connectedColor,
+    this.disconnectedColor,
+    this.unknownColor,
+  });
+
+  /// Connection status: true = connected, false = disconnected, null = unknown
+  final bool? isConnected;
+
+  /// Size of the icon
+  final double iconSize;
+
+  /// Color for the connected state (defaults to black)
+  final Color? connectedColor;
+
+  /// Color for the disconnected state (defaults to gray)
+  final Color? disconnectedColor;
+
+  /// Color for the unknown state (defaults to black)
+  final Color? unknownColor;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isConnected == true) {
+      return Icon(
+        Icons.wifi,
+        size: iconSize,
+        color: connectedColor ?? Colors.black,
+      );
+    } else if (isConnected == false) {
+      return Icon(
+        Icons.wifi_off,
+        size: iconSize,
+        color: disconnectedColor ?? Colors.grey,
+      );
+    } else {
+      return Icon(
+        Icons.signal_wifi_bad,
+        size: iconSize,
+        color: unknownColor ?? Colors.black,
+      );
+    }
+  }
+}
+
+@widgetbook.UseCase(
+  name: 'Connected',
+  type: FlexConnectivityIndicator,
+  path: '[Components]',
+)
+Widget connectedIndicator(BuildContext context) {
+  return const Center(
+    child: FlexConnectivityIndicator(
+      isConnected: true,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Disconnected',
+  type: FlexConnectivityIndicator,
+  path: '[Components]',
+)
+Widget disconnectedIndicator(BuildContext context) {
+  return const Center(
+    child: FlexConnectivityIndicator(
+      isConnected: false,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Unknown',
+  type: FlexConnectivityIndicator,
+  path: '[Components]',
+)
+Widget unknownIndicator(BuildContext context) {
+  return const Center(
+    child: FlexConnectivityIndicator(
+      isConnected: null,
+    ),
+  );
+}
+
+@widgetbook.UseCase(
+  name: 'Custom Colors',
+  type: FlexConnectivityIndicator,
+  path: '[Components]',
+)
+Widget customColorIndicator(BuildContext context) {
+  return const Center(
+    child: FlexConnectivityIndicator(
+      isConnected: true,
+      connectedColor: Colors.green,
+    ),
+  );
+}


### PR DESCRIPTION
# Connectivity Indicator Component Addition

## Changes
- Added new FlexConnectivityIndicator widget to flex_ui package
- Implemented three visual states for network connectivity (connected, disconnected, unknown)
- Added widgetbook use cases for component documentation

## Reason
The application needed a visual indicator to display network connectivity status to users. The indicator should be simple, clear, and usable across multiple applications that integrate with flex_core's connectivity monitoring.

## Resolution
Created a new FlexConnectivityIndicator component that:
- Displays appropriate Wi-Fi icons based on connection status (connected, disconnected, unknown)
- Takes a simple boolean parameter to determine its state
- Has customizable icon size and colors
- Works independently of flex_core, allowing it to be reused in any context
- Is fully documented with widgetbook examples showing all states

The component has a clean API that separates UI concerns from connectivity logic, making it easy to integrate with any data source that can provide connection status.

### icons
<img width="294" alt="image" src="https://github.com/user-attachments/assets/0516e216-579e-4547-a6bc-5fcf70e46585" />
<img width="309" alt="image" src="https://github.com/user-attachments/assets/5770598e-ac4b-4aa7-9e42-46223a3a90c8" />
<img width="269" alt="image" src="https://github.com/user-attachments/assets/a64c1707-da57-4494-97ec-817a5afe907a" />

