### PR TITLE
feat: add theme extensions accessors for flex color scheme

### DIFF
--- a/app/lib/utils/extensions.dart
+++ b/app/lib/utils/extensions.dart
@@ -13,8 +13,10 @@ extension ThemeExtension on BuildContext {
 
   /// Get the [FlexAppColorScheme] from the current theme.
   /// This is a custom extension that provides access to the FLEX color scheme
+  /// Defaults to [FlexAppColorScheme.lightScheme] if not found.
   FlexAppColorScheme get colors =>
-      Theme.of(this).extension<FlexAppColorScheme>()!;
+      Theme.of(this).extension<FlexAppColorScheme>() ??
+      FlexAppColorScheme.lightScheme;
 
   Size get deviceSize => MediaQuery.sizeOf(this);
   double get screenWidth => deviceSize.width;

--- a/app/lib/utils/extensions.dart
+++ b/app/lib/utils/extensions.dart
@@ -9,10 +9,12 @@ extension StringExtension on String? {
 extension ThemeExtension on BuildContext {
   ThemeData get theme => Theme.of(this);
   TextTheme get textTheme => Theme.of(this).textTheme;
+  ColorScheme get colorScheme => Theme.of(this).colorScheme;
+
+  /// Get the [FlexAppColorScheme] from the current theme.
+  /// This is a custom extension that provides access to the FLEX color scheme
   FlexAppColorScheme get colors =>
       Theme.of(this).extension<FlexAppColorScheme>()!;
-
-  // additional helpful getters
 
   Size get deviceSize => MediaQuery.sizeOf(this);
   double get screenWidth => deviceSize.width;
@@ -40,13 +42,13 @@ extension SnackBarStateExtension<T extends StatefulWidget> on State<T> {
         behavior: SnackBarBehavior.floating,
         action: isDismissable && dismissLabel != null
             ? SnackBarAction(
-          label: dismissLabel,
-          textColor: Colors.white,
-          onPressed: () {
-            if (!mounted) return;
-            ScaffoldMessenger.of(context).hideCurrentSnackBar();
-          },
-        )
+                label: dismissLabel,
+                textColor: Colors.white,
+                onPressed: () {
+                  if (!mounted) return;
+                  ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                },
+              )
             : null,
       ),
     );


### PR DESCRIPTION
This adds a ThemeExtension for Material `colorScheme` and `FlexAppColorScheme` with `context.colors`