### PR TITLE
fix(widget): product card accepts widget for icon

### DIFF
--- a/app/lib/widgets/cards/productCard/product_card.dart
+++ b/app/lib/widgets/cards/productCard/product_card.dart
@@ -63,7 +63,7 @@ class FlexProductCard extends StatelessWidget {
   final Color? leftIconBackgroundColor;
   final Color? leftIconTextColor;
   final bool displayRightIcon;
-  final Icon? rightIcon;
+  final Widget? rightIcon;
   final ButtonStyle? rightIconButtonStyle;
   final String? rightIconSemanticsLabel;
   final VoidCallback? onPressedRightIcon;

--- a/app/lib/widgets/cards/productCard/shared/right_bottom_icon_button.dart
+++ b/app/lib/widgets/cards/productCard/shared/right_bottom_icon_button.dart
@@ -8,7 +8,7 @@ class RightBottomIconButton extends StatelessWidget {
     required this.onPressed,
   });
 
-  final Icon icon;
+  final Widget icon;
   final ButtonStyle? iconButtonStyle;
   final VoidCallback? onPressed;
 


### PR DESCRIPTION
## Change
- `ProductCard` now accepts a `Widget` instead of being restricted to Icon

## Reason
- This allows for customized widgets to be passed as the icon, for instance adding custom Padding around the icon

## Result
- allows for passing in padded widget:

| Before | After |
|--------|-------|
| <img width="82" alt="image" src="https://github.com/user-attachments/assets/5646b1fa-d60a-438c-9bc6-d35b0d3ec4fc" /> | ![image](https://github.com/user-attachments/assets/4c2b5c65-0453-4f3e-b8d3-395f5b51cf57)|





