### PR TITLE
chore(utils): use safe emit

### DIFF
--- a/app/lib/utils/extensions.dart
+++ b/app/lib/utils/extensions.dart
@@ -1,3 +1,4 @@
+import 'package:bloc/bloc.dart';
 import 'package:flex_ui/tokens/colors.dart';
 import 'package:flutter/material.dart';
 
@@ -84,3 +85,18 @@ extension SnackBarContextExtension on BuildContext {
     );
   }
 }
+
+mixin SafeEmitter<T> on Cubit<T> {
+  void safeEmit(T state) {
+    if (isClosed) return;
+    emit(state);
+  }
+}
+
+mixin SafeBlocEmitter<T> on BlocBase<T> {
+  void safeEmit(Emitter<T> emit, T state) {
+    if (isClosed) return;
+    emit(state);
+  }
+}
+

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.12.0"
+  bloc:
+    dependency: "direct main"
+    description:
+      name: bloc
+      sha256: "52c10575f4445c61dd9e0cafcc6356fdd827c4c64dd7945ef3c4105f6b6ac189"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   alchemist: ^0.11.0
+  bloc: ^9.0.0
   cached_network_image: ^3.4.1
   carousel_slider: ^5.0.0
   file: ^7.0.1


### PR DESCRIPTION
## Changes


- Updated `pubspec.yaml` to include the `bloc` package version `^9.0.0`


## Reason

- To support safe and defensive state emission in both Cubits and Blocs
- Avoid runtime exceptions from emitting after disposal, especially during async operations

## Result

- Centralized `safeEmit()` logic now available to all Cubits and Blocs
- `bloc` is an explicitly declared dependency
- Project is more robust against edge cases where `emit()` might otherwise fail
